### PR TITLE
🧹 Janitor: Deduplicate DAY_MS fetch interval constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,8 @@ export const DEFAULT_PR_TARGET = 100;
 export const MAX_PR_TARGET = 1000;
 export const BATCH_SIZE = 100;
 
+/** Milliseconds in one day (used for fetch windows and adaptive intervals). */
+export const DAY_MS = 24 * 60 * 60 * 1000;
 // Adaptive fetch: initial load covers this many days
 export const INITIAL_FETCH_DAYS = 7;
 // Each "load more" extends backwards by this many days

--- a/src/services/AdaptiveScopeFetcher.ts
+++ b/src/services/AdaptiveScopeFetcher.ts
@@ -1,7 +1,7 @@
 import { PullRequest } from '../types';
+import { DAY_MS } from '../constants';
 import { isAbortError } from '../utils/abort';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const MIN_INTERVAL_MS = DAY_MS;
 const MAX_INTERVAL_MS = 30 * DAY_MS;
 const WIDEN_THRESHOLD = 200;

--- a/src/services/prFetchSession.ts
+++ b/src/services/prFetchSession.ts
@@ -7,10 +7,8 @@ import {
 } from './AdaptiveScopeFetcher';
 import { createSerialQueue } from './serialQueue';
 import { pullStreamsUntilIdle } from './prStorePull';
-import { INITIAL_FETCH_DAYS, LOAD_MORE_DAYS } from '../constants';
+import { DAY_MS, INITIAL_FETCH_DAYS, LOAD_MORE_DAYS } from '../constants';
 import type { PullRequest } from '../types';
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface PRFetchSessionStatus {
   isLoading: boolean;


### PR DESCRIPTION
## What
Export a single `DAY_MS` from `src/constants.ts` and import it in:
- `src/services/AdaptiveScopeFetcher.ts` (MIN/MAX interval, `INITIAL_INTERVAL_MS`)
- `src/services/prFetchSession.ts` (initial / load-more date windows)

## Why
The same magic `24 * 60 * 60 * 1000` was defined twice in production code. Centralizing it next to `INITIAL_FETCH_DAYS` / `LOAD_MORE_DAYS` keeps time-related fetch constants in one place and avoids drift.

## Behavior
No behavior change — same numeric value, same consumers.

## Verification
- `npx eslint src/constants.ts src/services/AdaptiveScopeFetcher.ts src/services/prFetchSession.ts`
- `npx playwright test tests/adaptive-scope-fetcher.spec.ts tests/pr-fetch-session.spec.ts` (11 passed)

## Scope
Independent of Jules-owned PRs/files. Minimal touch: 3 files only.