### PR TITLE
🧹 Janitor: Centralize auth session cookie helpers

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -1,7 +1,12 @@
-import { SignJWT, jwtVerify } from 'jose';
+import { jwtVerify } from 'jose';
 import { parse } from 'cookie';
 import { reportError } from '../../../utils/errorReporting';
 import { isSecureRequest } from '../../../utils/requestUtils';
+import {
+  buildSessionCookie,
+  clearOAuthStateCookie,
+  signSessionJwt,
+} from './cookies';
 
 export async function GET({ request }: { request: Request }) {
   const requestUrl = new URL(request.url);
@@ -127,22 +132,19 @@ export async function GET({ request }: { request: Request }) {
   }
 
   // Create a secure session JWT
-  const session = await new SignJWT({
-    github_token: access_token,
-    mode: mode,
-  })
-    .setProtectedHeader({ alg: 'HS256' })
-    .setIssuedAt()
-    .setExpirationTime('7d')
-    .sign(secret);
+  const session = await signSessionJwt(
+    {
+      github_token: access_token,
+      mode: mode,
+    },
+    secret,
+  );
 
   const baseUrl = requestUrl.origin;
 
   // Set the session cookie and clear the state cookie
-  const sessionCookie = `session=${session}; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=${
-    60 * 60 * 24 * 7
-  }; Path=/`;
-  const clearStateCookie = `oauth_state=; HttpOnly; Path=/; Max-Age=0`;
+  const sessionCookie = buildSessionCookie(session, isHttps);
+  const clearStateCookie = clearOAuthStateCookie();
 
   // 🛡️ SENTINEL: To set multiple cookies, we must use multiple `Set-Cookie` headers.
   // Using a single header with a comma-separated list is not compliant with RFC 6265.

--- a/src/pages/api/auth/cookies.ts
+++ b/src/pages/api/auth/cookies.ts
@@ -1,0 +1,41 @@
+import { SignJWT } from 'jose';
+
+/** Session cookie / JWT TTL: 7 days. */
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+export const SESSION_JWT_EXPIRATION = '7d';
+
+/** OAuth state cookie TTL: 5 minutes. */
+export const OAUTH_STATE_MAX_AGE_SECONDS = 300;
+
+export function buildSessionCookie(token: string, isHttps: boolean): string {
+  return `session=${token}; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=${SESSION_MAX_AGE_SECONDS}; Path=/`;
+}
+
+export function clearSessionCookie(isHttps: boolean): string {
+  return `session=; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=0; Path=/`;
+}
+
+export function buildOAuthStateCookie(
+  stateToken: string,
+  isHttps: boolean,
+): string {
+  return `oauth_state=${stateToken}; HttpOnly; ${
+    isHttps ? 'Secure; ' : ''
+  }Path=/; SameSite=Lax; Max-Age=${OAUTH_STATE_MAX_AGE_SECONDS}`;
+}
+
+/** Clears oauth_state. Attribute set matches existing callback behavior (no Secure/SameSite). */
+export function clearOAuthStateCookie(): string {
+  return `oauth_state=; HttpOnly; Path=/; Max-Age=0`;
+}
+
+export async function signSessionJwt(
+  payload: { github_token: string; mode: string },
+  secret: Uint8Array,
+): Promise<string> {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(SESSION_JWT_EXPIRATION)
+    .sign(secret);
+}

--- a/src/pages/api/auth/github.ts
+++ b/src/pages/api/auth/github.ts
@@ -1,6 +1,7 @@
 import { SignJWT } from 'jose';
 import { reportError } from '../../../utils/errorReporting';
 import { isSecureRequest } from '../../../utils/requestUtils';
+import { buildOAuthStateCookie } from './cookies';
 
 export async function GET({ request }: { request: Request }) {
   const clientId = import.meta.env.GITHUB_CLIENT_ID;
@@ -53,10 +54,7 @@ export async function GET({ request }: { request: Request }) {
 
   // Keep cookie as an optional second validation channel (double-submit style).
   const isHttps = isSecureRequest(request);
-
-  const cookie = `oauth_state=${stateToken}; HttpOnly; ${
-    isHttps ? 'Secure; ' : ''
-  }Path=/; SameSite=Lax; Max-Age=300`; // 5 minutes expiry
+  const cookie = buildOAuthStateCookie(stateToken, isHttps);
 
   // Redirect to GitHub, including the CSRF state and the new cookie.
   return new Response(null, {

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,4 +1,5 @@
 import { isSecureRequest } from '../../../utils/requestUtils';
+import { clearSessionCookie } from './cookies';
 
 export async function POST({ request }: { request: Request }) {
   const isHttps = isSecureRequest(request);
@@ -7,11 +8,8 @@ export async function POST({ request }: { request: Request }) {
     headers: { 'Content-Type': 'application/json' },
   });
 
-  // Limpar cookie
-  response.headers.set(
-    'Set-Cookie',
-    `session=; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=0; Path=/`,
-  );
+  // Clear session cookie
+  response.headers.set('Set-Cookie', clearSessionCookie(isHttps));
 
   return response;
 }

--- a/src/pages/api/auth/pat.ts
+++ b/src/pages/api/auth/pat.ts
@@ -1,5 +1,5 @@
-import { SignJWT } from 'jose';
 import { isSecureRequest } from '../../../utils/requestUtils';
+import { buildSessionCookie, signSessionJwt } from './cookies';
 
 interface PATAuthRequestBody {
   token?: string;
@@ -49,14 +49,13 @@ export async function POST({ request }: { request: Request }) {
   }
 
   const secret = new TextEncoder().encode(secretValue);
-  const session = await new SignJWT({
-    github_token: token,
-    mode,
-  })
-    .setProtectedHeader({ alg: 'HS256' })
-    .setIssuedAt()
-    .setExpirationTime('7d')
-    .sign(secret);
+  const session = await signSessionJwt(
+    {
+      github_token: token,
+      mode,
+    },
+    secret,
+  );
 
   const isHttps = isSecureRequest(request);
 
@@ -67,12 +66,7 @@ export async function POST({ request }: { request: Request }) {
     },
   });
 
-  response.headers.set(
-    'Set-Cookie',
-    `session=${session}; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=${
-      60 * 60 * 24 * 7
-    }; Path=/`,
-  );
+  response.headers.set('Set-Cookie', buildSessionCookie(session, isHttps));
 
   return response;
 }


### PR DESCRIPTION
## Assumptions
- Cookie string attribute order and flags (HttpOnly, SameSite, Secure when HTTPS, Path, Max-Age) must stay byte-for-byte equivalent to the previous inline construction.
- Clearing `oauth_state` intentionally omits Secure/SameSite (matches prior callback behavior).
- Colocating helpers under `src/pages/api/auth/cookies.ts` is appropriate because only these API routes build these cookies.
- Optional `signSessionJwt` is in scope: same HS256 + `7d` behavior used by PAT and OAuth callback.

## What changed
- Added `src/pages/api/auth/cookies.ts` with:
  - `SESSION_MAX_AGE_SECONDS` / `SESSION_JWT_EXPIRATION` (single 7-day TTL source)
  - `OAUTH_STATE_MAX_AGE_SECONDS` (300s)
  - `buildSessionCookie` / `clearSessionCookie`
  - `buildOAuthStateCookie` / `clearOAuthStateCookie`
  - `signSessionJwt`
- Wired helpers into `pat.ts`, `callback.ts`, `logout.ts`, `github.ts`.
- Replaced Portuguese logout comment with English.

## Out of scope / independence
- **No** client `services/auth.ts` changes (Jules #326).
- **No** `reportError` migrations or other error-handling refactors.
- **No** touch to Jules-owned files (`bulkProgress.ts`, `LoginPage.tsx`, `relay/environment.ts`, `PRList.tsx`, `bulkActions.ts`, `tests/utils/translations.ts`, etc.).
- Independent of Jules #325 / #326 / #328 — pure DRY of server Set-Cookie / session JWT construction.

## Verification
- `npx eslint src/pages/api/auth/` — pass
- Local string equality checks for all cookie builders (HTTPS and non-HTTPS) against previous formats — pass
- `mise run install` / full Playwright install needs sudo for system deps in this environment; not required for this pure TypeScript refactor