### PR TITLE
🧹 Janitor: Reuse countCiStatuses in PR group sort

### DIFF
--- a/src/services/prSort.ts
+++ b/src/services/prSort.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_SORT_STRATEGY, SORT_STRATEGIES } from '../constants';
 import type { PRGroup, PullRequest, SortStrategy } from '../types';
+import { countCiStatuses } from './ciStatus';
 
 function isSortStrategy(value: string): value is SortStrategy {
   return Object.prototype.hasOwnProperty.call(SORT_STRATEGIES, value);
@@ -34,14 +35,6 @@ function minTimestamp(
     if (!Number.isNaN(time) && time < min) min = time;
   }
   return min === Number.POSITIVE_INFINITY ? 0 : min;
-}
-
-function countCiFailures(prs: PullRequest[]): number {
-  let failures = 0;
-  for (const pr of prs) {
-    if (pr.ciStatus === 'FAILURE') failures++;
-  }
-  return failures;
 }
 
 function countRepos(prs: PullRequest[]): number {
@@ -95,7 +88,10 @@ export function sortGroups(
       case 'name':
         return compareByName(a, b);
       case 'ci_failures':
-        primary = compareDesc(countCiFailures(a.prs), countCiFailures(b.prs));
+        primary = compareDesc(
+          countCiStatuses(a.prs).failure,
+          countCiStatuses(b.prs).failure,
+        );
         break;
       case 'repos':
         primary = compareDesc(countRepos(a.prs), countRepos(b.prs));

--- a/tests/pr-sort.spec.ts
+++ b/tests/pr-sort.spec.ts
@@ -166,6 +166,21 @@ test.describe('sortGroups', () => {
     ]);
   });
 
+  test('ci_failures counts only FAILURE (not PENDING or SUCCESS)', () => {
+    const withPending = [
+      makeGroup('many-pending', [
+        makePR('p1', { ciStatus: 'PENDING' }),
+        makePR('p2', { ciStatus: 'PENDING' }),
+        makePR('p3', { ciStatus: 'SUCCESS' }),
+      ]),
+      makeGroup('one-failure', [makePR('f1', { ciStatus: 'FAILURE' })]),
+    ];
+    expect(sortGroups(withPending, 'ci_failures').map((g) => g.key)).toEqual([
+      'one-failure',
+      'many-pending',
+    ]);
+  });
+
   test('repos sorts by unique repositories descending', () => {
     expect(sortGroups(groups, 'repos').map((g) => g.key)).toEqual([
       'alpha',


### PR DESCRIPTION
## What

Remove the private `countCiFailures` helper in `prSort.ts` and reuse `countCiStatuses` from `ciStatus.ts` for the `ci_failures` sort strategy.

## Why

`countCiFailures` only counted `ciStatus === 'FAILURE'`, which is the same as `countCiStatuses(prs).failure`. Keeping two counters risks drift in wording/behavior whenever CI status handling changes.

Behavior is unchanged: sort still ranks groups by **FAILURE-only** counts (PENDING/SUCCESS do not contribute to the sort key).

## Files

- `src/services/prSort.ts` — import `countCiStatuses`, delete `countCiFailures`
- `tests/pr-sort.spec.ts` — assert PENDING/SUCCESS are not treated as failures for sort

## Verification

```bash
npx playwright test tests/pr-sort.spec.ts
```

Result: **11 passed**

## Scope

Single-item janitor PR. Independent of Jules work (#325 / #326 / #328). Does not touch Jules-related files.