### PR TITLE
🧹 Janitor: Fix PRProvider ref update during render

### DIFF
--- a/src/context/PRProvider.tsx
+++ b/src/context/PRProvider.tsx
@@ -55,7 +55,9 @@ export function PRProvider({ children }: PRProviderProps) {
   }, []);
 
   const onBatchRef = useRef(onBatch);
-  onBatchRef.current = onBatch;
+  useEffect(() => {
+    onBatchRef.current = onBatch;
+  }, [onBatch]);
 
   const getSession = useCallback((): PRFetchSession => {
     if (environmentRef.current !== environment) {


### PR DESCRIPTION
## What / Why

ESLint `react-hooks/refs` flags updating `onBatchRef.current` during render in `PRProvider.tsx`. That assignment is illegal under the React Compiler / eslint-plugin-react-hooks rule and can lead to inconsistent behavior during concurrent rendering.

## Fix

Sync the ref in `useEffect` instead of during render, matching the existing pattern for `pendingConfirmationRef` in `BulkActionProvider.tsx`.

`createPRFetchSession` still receives a stable `onBatch` wrapper that reads `onBatchRef.current`, so callers always invoke the latest callback.

## How verified

- `npx eslint src/context/PRProvider.tsx` — clean (no `react-hooks/refs`)
- Full `npx eslint .` — only pre-existing unrelated issue in `tests/auth-session-cache.spec.ts` (`FetchArgs` unused); not introduced by this change

## Scope

- Single file: `src/context/PRProvider.tsx`
- Independent of Jules PRs #325 / #326 / #328 (does not touch their owned files)