### PR TITLE
🧹 Janitor: Fix unused FetchArgs ESLint error

### DIFF
--- a/tests/auth-session-cache.spec.ts
+++ b/tests/auth-session-cache.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from '@playwright/test';
 import { AuthService, invalidateAuthSessionCache } from '../src/services/auth';
 import { API_ROUTES } from '../src/constants';
 
-type FetchArgs = [input: RequestInfo | URL, init?: RequestInit];
-
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,


### PR DESCRIPTION
## What
Remove unused `FetchArgs` type alias from `tests/auth-session-cache.spec.ts`.

## Why
`npx eslint .` failed with `@typescript-eslint/no-unused-vars` on the only remaining error:

```
tests/auth-session-cache.spec.ts
  5:6  error  'FetchArgs' is defined but never used  @typescript-eslint/no-unused-vars
```

The type was never referenced after introduction; removing it restores a clean lint.

## Verification
- `npx eslint tests/auth-session-cache.spec.ts` — pass (exit 0)
- `npx eslint .` — pass (exit 0, zero errors)