### PR TITLE
🧹 Janitor: Remove Math.random from bulkProgress id fallback

### DIFF
--- a/src/services/bulkProgress.ts
+++ b/src/services/bulkProgress.ts
@@ -74,7 +74,10 @@ function createRandomIdSuffix(): string {
   }
 
   fallbackIdCounter += 1;
-  return `fallback_${fallbackIdCounter}_${Math.random().toString(36).slice(2, 11)}`;
+  // Absolute last resort when crypto is unavailable (extremely rare in modern
+  // browsers/Node). Counter + timestamp keep ids unique within the process
+  // without non-crypto Math.random noise.
+  return `fallback_${fallbackIdCounter}_${Date.now()}`;
 }
 
 export function createBulkOperationId(): string {


### PR DESCRIPTION
## Summary
- Removes the last `Math.random()` usage in `createRandomIdSuffix` (`src/services/bulkProgress.ts`).
- Crypto paths unchanged: prefer `crypto.randomUUID`, then UUID-shaped `getRandomValues`.
- Absolute last fallback (no crypto at all): `fallback_${counter}_${Date.now()}` for process-local uniqueness without non-crypto PRNG noise.
- `createBulkOperationId` still prefixes `op_${Date.now()}_...`.

## Assumptions
- Modern browsers and this app’s Node 25 runtime expose Web Crypto (`randomUUID` / `getRandomValues`); the counter path is only a belt-and-suspenders branch.
- Operation ids only need uniqueness within the session/process, not cryptographic unpredictability once crypto is gone.

## Alternatives considered
- Throw if crypto is missing — stricter, but would break exotic environments for little gain.
- Keep `Math.random` — leaves known tech-debt / eslint-security noise.
- `crypto.getRandomValues` polyfill package — unnecessary; runtimes already provide crypto.

## Test plan
- [x] `npx eslint src/services/bulkProgress.ts`
- [x] `npx playwright test tests/bulk-action-confirm.spec.ts` (5 passed, including getRandomValues path)
- [x] Confirmed no remaining `Math.random` in `bulkProgress.ts`
- [ ] CI green on PR