### PR TITLE
🧹 Janitor: Parse PR state and grouping URL params safely

### DIFF
--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -17,9 +17,13 @@ import { calculateStats } from '../services/prStats';
 import { PRGroupCard } from './PRGroupCard';
 import { PRGroupDetail } from './PRGroupDetail';
 import { reportError } from '../utils/errorReporting';
-import { PRGroup, GroupingStrategy } from '../types';
-import { PRState, URL_SEARCH_PARAMS } from '../constants';
+import { PRGroup } from '../types';
+import { URL_SEARCH_PARAMS } from '../constants';
 import { parseSortStrategy } from '../services/prSort';
+import {
+  parseGroupingStrategy,
+  parsePRState,
+} from '../services/urlParams';
 import { PRListStats } from './PRListStats';
 import { PRListFilters } from './PRListFilters';
 import { usePRContext } from '../context/PRContext';
@@ -44,13 +48,12 @@ function PRListContent() {
 
   // Read filters from URL
   const filterRepo = searchParams.get(URL_SEARCH_PARAMS.REPO) || '';
-  const filterState = (searchParams.get(URL_SEARCH_PARAMS.STATE) ||
-    'ALL') as PRState;
+  const filterState = parsePRState(searchParams.get(URL_SEARCH_PARAMS.STATE));
   const filterAuthor = searchParams.get(URL_SEARCH_PARAMS.AUTHOR) || '';
   const filterOwner = searchParams.get(URL_SEARCH_PARAMS.OWNER) || '';
-  const groupBy =
-    (searchParams.get(URL_SEARCH_PARAMS.GROUP_BY) as GroupingStrategy) ||
-    'renovate';
+  const groupBy = parseGroupingStrategy(
+    searchParams.get(URL_SEARCH_PARAMS.GROUP_BY),
+  );
   const sortBy = parseSortStrategy(searchParams.get(URL_SEARCH_PARAMS.SORT_BY));
 
   // Persist filters in sessionStorage

--- a/src/services/urlParams.ts
+++ b/src/services/urlParams.ts
@@ -1,0 +1,33 @@
+import { GROUPING_STRATEGIES, PR_STATES, type PRState } from '../constants';
+import type { GroupingStrategy } from '../types';
+
+const DEFAULT_PR_STATE: PRState = 'ALL';
+const DEFAULT_GROUPING_STRATEGY: GroupingStrategy = 'renovate';
+
+function isPRState(value: string): value is PRState {
+  return (PR_STATES as readonly string[]).includes(value);
+}
+
+/**
+ * Parses a URL/search param into a valid PRState.
+ * Invalid or missing values fall back to `'ALL'`.
+ */
+export function parsePRState(value: string | null | undefined): PRState {
+  if (value && isPRState(value)) return value;
+  return DEFAULT_PR_STATE;
+}
+
+function isGroupingStrategy(value: string): value is GroupingStrategy {
+  return Object.prototype.hasOwnProperty.call(GROUPING_STRATEGIES, value);
+}
+
+/**
+ * Parses a URL/search param into a valid GroupingStrategy.
+ * Invalid or missing values fall back to `'renovate'`.
+ */
+export function parseGroupingStrategy(
+  value: string | null | undefined,
+): GroupingStrategy {
+  if (value && isGroupingStrategy(value)) return value;
+  return DEFAULT_GROUPING_STRATEGY;
+}

--- a/tests/url-params.spec.ts
+++ b/tests/url-params.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import {
+  parseGroupingStrategy,
+  parsePRState,
+} from '../src/services/urlParams';
+import { GROUPING_STRATEGIES, PR_STATES } from '../src/constants';
+
+test.describe('parsePRState', () => {
+  test('defaults invalid or missing values to ALL', () => {
+    expect(parsePRState(null)).toBe('ALL');
+    expect(parsePRState(undefined)).toBe('ALL');
+    expect(parsePRState('')).toBe('ALL');
+    expect(parsePRState('nope')).toBe('ALL');
+    expect(parsePRState('open')).toBe('ALL');
+  });
+
+  test('accepts known PR states', () => {
+    for (const state of PR_STATES) {
+      expect(parsePRState(state)).toBe(state);
+    }
+  });
+});
+
+test.describe('parseGroupingStrategy', () => {
+  test('defaults invalid or missing values to renovate', () => {
+    expect(parseGroupingStrategy(null)).toBe('renovate');
+    expect(parseGroupingStrategy(undefined)).toBe('renovate');
+    expect(parseGroupingStrategy('')).toBe('renovate');
+    expect(parseGroupingStrategy('nope')).toBe('renovate');
+    expect(parseGroupingStrategy('Renovate')).toBe('renovate');
+  });
+
+  test('accepts known grouping strategies', () => {
+    for (const key of Object.keys(GROUPING_STRATEGIES)) {
+      expect(parseGroupingStrategy(key)).toBe(key);
+    }
+  });
+});


### PR DESCRIPTION
## What
Validate `state` and `group_by` URL search params instead of casting them with `as PRState` / `as GroupingStrategy`.

- Add `parsePRState` and `parseGroupingStrategy` in `src/services/urlParams.ts` (same membership-check pattern as `parseSortStrategy` / `parseMergeMethod`)
- Wire `PRList.tsx` to use the parsers
- Unit tests in `tests/url-params.spec.ts`

## Why
Invalid URL values (typos, hand-edited query strings, stale bookmarks) could poison filters and grouping via unsafe casts. Sort already used a safe parser; state and group_by did not.

Defaults match previous fallbacks: `'ALL'` for state, `'renovate'` for grouping.

## Verification
```bash
npx playwright test tests/url-params.spec.ts
```
4 passed.