### PR TITLE
🧹 Janitor: Reuse toPendingProgress and English comments in bulkActions

### DIFF
--- a/src/services/bulkActions.ts
+++ b/src/services/bulkActions.ts
@@ -6,6 +6,7 @@ import { executeWithRetry } from '../utils/retry';
 import { isRateLimitErrorMessage } from '../utils/rateLimitError';
 import { DEFAULT_MERGE_METHOD } from '../constants';
 import i18n from '../i18n';
+import { toPendingProgress } from './bulkProgress';
 import type {
   PullRequest,
   BulkActionProgress,
@@ -195,15 +196,10 @@ export const BulkActionsService = {
     const progressMap = new Map<string, BulkActionProgress>();
     const mergeMethod = options?.mergeMethod ?? DEFAULT_MERGE_METHOD;
 
-    // Inicializar progresso
-    prs.forEach((pr) => {
-      progressMap.set(pr.id, {
-        prId: pr.id,
-        prNumber: pr.number,
-        prTitle: pr.title,
-        status: 'pending',
-      });
-    });
+    // Initialize progress entries as pending
+    for (const item of toPendingProgress(prs)) {
+      progressMap.set(item.prId, item);
+    }
 
     onProgress(Array.from(progressMap.values()));
 
@@ -212,9 +208,9 @@ export const BulkActionsService = {
         ? (id: string) => this.mergePullRequest(id, mergeMethod)
         : (id: string) => this.closePullRequest(id);
 
-    // Executar ações sequencialmente com retry e exponential backoff
+    // Run actions sequentially with retry and exponential backoff
     for (const pr of prs) {
-      // Atualizar status para processing
+      // Mark this PR as processing
       progressMap.set(pr.id, {
         ...progressMap.get(pr.id)!,
         status: 'processing',
@@ -259,7 +255,7 @@ export const BulkActionsService = {
           },
         );
       } catch (err) {
-        // Erro após todas as retentativas ou erro inesperado
+        // Failed after all retries, or unexpected error
         result = {
           success: false,
           prId: pr.id,


### PR DESCRIPTION
## What

Focused cleanup in `src/services/bulkActions.ts` only:

1. **DRY progress init** — `executeBulkAction` no longer hand-builds pending progress entries with `forEach` + inline object shape. It now reuses `toPendingProgress` from `./bulkProgress` (same helper already used by BulkActionProvider / confirm handoff).
2. **Comment language** — Portuguese inline comments translated to concise English to match the rest of the codebase:
   - `// Inicializar progresso` → `// Initialize progress entries as pending`
   - `// Executar ações sequencialmente com retry e exponential backoff` → `// Run actions sequentially with retry and exponential backoff`
   - `// Atualizar status para processing` → `// Mark this PR as processing`
   - `// Erro após todas as retentativas ou erro inesperado` → `// Failed after all retries, or unexpected error`

## Why

- Pending progress construction was duplicated between `bulkActions` and `bulkProgress`.
- Mixed PT/EN comments hurt consistency; JSDoc and neighboring comments are already English.

## Out of scope

- No changes to merge/close/retry behavior.
- No changes to `bulkProgress.ts` (import only).
- No error-reporting migrations.

## Verification

- `npx eslint src/services/bulkActions.ts` — pass
- `npx tsc --noEmit` — no errors in `bulkActions` / `bulkProgress`
- `npx playwright test tests/bulk-actions.spec.ts tests/bulk-action-confirm.spec.ts` — **7 passed**