### PR TITLE
fix(security): clear oauth_state with same cookie attrs as set

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -144,7 +144,7 @@ export async function GET({ request }: { request: Request }) {
 
   // Set the session cookie and clear the state cookie
   const sessionCookie = buildSessionCookie(session, isHttps);
-  const clearStateCookie = clearOAuthStateCookie();
+  const clearStateCookie = clearOAuthStateCookie(isHttps);
 
   // 🛡️ SENTINEL: To set multiple cookies, we must use multiple `Set-Cookie` headers.
   // Using a single header with a comma-separated list is not compliant with RFC 6265.

--- a/src/pages/api/auth/cookies.ts
+++ b/src/pages/api/auth/cookies.ts
@@ -24,9 +24,11 @@ export function buildOAuthStateCookie(
   }Path=/; SameSite=Lax; Max-Age=${OAUTH_STATE_MAX_AGE_SECONDS}`;
 }
 
-/** Clears oauth_state. Attribute set matches existing callback behavior (no Secure/SameSite). */
-export function clearOAuthStateCookie(): string {
-  return `oauth_state=; HttpOnly; Path=/; Max-Age=0`;
+/** Clears oauth_state with the same attributes used when setting it. */
+export function clearOAuthStateCookie(isHttps: boolean): string {
+  return `oauth_state=; HttpOnly; ${
+    isHttps ? 'Secure; ' : ''
+  }Path=/; SameSite=Lax; Max-Age=0`;
 }
 
 export async function signSessionJwt(

--- a/tests/oauth-state-cookie.spec.ts
+++ b/tests/oauth-state-cookie.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import {
+  buildOAuthStateCookie,
+  clearOAuthStateCookie,
+} from '../src/pages/api/auth/cookies';
+
+test.describe('oauth_state cookie helpers', () => {
+  test('clear uses same Secure/SameSite/Path/HttpOnly as set when HTTPS', () => {
+    const set = buildOAuthStateCookie('token', true);
+    const clear = clearOAuthStateCookie(true);
+
+    expect(set).toContain('Secure');
+    expect(set).toContain('SameSite=Lax');
+    expect(set).toContain('HttpOnly');
+    expect(set).toContain('Path=/');
+
+    expect(clear).toBe(
+      'oauth_state=; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=0',
+    );
+    expect(clear).toContain('Secure');
+    expect(clear).toContain('SameSite=Lax');
+    expect(clear).toContain('HttpOnly');
+    expect(clear).toContain('Path=/');
+    expect(clear).toContain('Max-Age=0');
+  });
+
+  test('clear omits Secure when not HTTPS, still matches set attrs', () => {
+    const set = buildOAuthStateCookie('token', false);
+    const clear = clearOAuthStateCookie(false);
+
+    expect(set).not.toContain('Secure');
+    expect(clear).toBe(
+      'oauth_state=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0',
+    );
+    expect(clear).not.toContain('Secure');
+    expect(clear).toContain('SameSite=Lax');
+  });
+});


### PR DESCRIPTION
## Problem

`buildOAuthStateCookie` sets `HttpOnly`, `Path=/`, `SameSite=Lax`, and `Secure` on HTTPS. `clearOAuthStateCookie` only returned `oauth_state=; HttpOnly; Path=/; Max-Age=0`, so browsers could keep the stale CSRF cookie after the OAuth callback.

## Change

- `clearOAuthStateCookie(isHttps)` now mirrors set attributes (`Secure` when HTTPS, `SameSite=Lax`, same Path/HttpOnly).
- Callback passes `isHttps` into clear (same flag used for the session cookie).
- Unit coverage for HTTPS and non-HTTPS clear strings.

**Contract note:** `clearOAuthStateCookie` now requires `isHttps: boolean` (was zero-arg). Only the auth callback call site existed; it is updated.

## How verified

```text
npx playwright test tests/oauth-state-cookie.spec.ts
# 2 passed
```

Finding: `oauth-clear-cookie-attrs`