### PR TITLE
fix(relay): retry GraphQL 403 only when rate-limited

### DIFF
--- a/src/relay/environment.ts
+++ b/src/relay/environment.ts
@@ -18,6 +18,10 @@ import {
   isAbortError,
 } from '../utils/abort';
 import { APP_ROUTES } from '../constants';
+import {
+  resolveRetryDelayMs,
+  shouldRetryAsRateLimit,
+} from '../utils/rateLimitError';
 
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const MAX_RETRIES = 3;
@@ -81,13 +85,14 @@ async function executeGithubGraphql(
     }
 
     if (
-      (response.status === 429 || response.status === 403) &&
+      shouldRetryAsRateLimit(response.status, response.headers) &&
       attempt < MAX_RETRIES
     ) {
-      const retryAfter = response.headers.get('Retry-After');
-      const delay = retryAfter
-        ? parseInt(retryAfter, 10) * 1000
-        : BASE_RETRY_DELAY_MS * Math.pow(2, attempt);
+      const delay = resolveRetryDelayMs(
+        response.headers.get('Retry-After'),
+        attempt,
+        BASE_RETRY_DELAY_MS,
+      );
       console.warn(
         `Rate limited (${response.status}), retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`,
       );

--- a/src/utils/rateLimitError.ts
+++ b/src/utils/rateLimitError.ts
@@ -8,3 +8,35 @@ export function isRateLimitErrorMessage(message: string): boolean {
     msg.includes('429')
   );
 }
+
+/**
+ * Delay for the next retry: use Retry-After (seconds) when finite and non-negative;
+ * otherwise exponential backoff from baseDelayMs.
+ */
+export function resolveRetryDelayMs(
+  retryAfterHeader: string | null,
+  attempt: number,
+  baseDelayMs: number,
+): number {
+  if (retryAfterHeader != null && retryAfterHeader !== '') {
+    const seconds = parseInt(retryAfterHeader, 10);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return seconds * 1000;
+    }
+  }
+  return baseDelayMs * Math.pow(2, attempt);
+}
+
+/**
+ * Whether this HTTP status/headers should trigger a rate-limit retry.
+ * 429 always; 403 only when rate-limit signals are present (not permission denials).
+ */
+export function shouldRetryAsRateLimit(
+  status: number,
+  headers: Headers,
+): boolean {
+  if (status === 429) return true;
+  if (status !== 403) return false;
+  if (headers.get('Retry-After')) return true;
+  return headers.get('X-RateLimit-Remaining') === '0';
+}

--- a/tests/bulk-actions.spec.ts
+++ b/tests/bulk-actions.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { isRateLimitErrorMessage } from '../src/utils/rateLimitError';
+import {
+  isRateLimitErrorMessage,
+  resolveRetryDelayMs,
+  shouldRetryAsRateLimit,
+} from '../src/utils/rateLimitError';
 
 test.describe('isRateLimitErrorMessage', () => {
   test('matches common GitHub rate-limit error strings', () => {
@@ -15,5 +19,54 @@ test.describe('isRateLimitErrorMessage', () => {
     );
     expect(isRateLimitErrorMessage('Network error')).toBe(false);
     expect(isRateLimitErrorMessage('')).toBe(false);
+  });
+});
+
+test.describe('resolveRetryDelayMs', () => {
+  const base = 1000;
+
+  test('uses finite non-negative Retry-After in seconds', () => {
+    expect(resolveRetryDelayMs('5', 0, base)).toBe(5000);
+    expect(resolveRetryDelayMs('0', 2, base)).toBe(0);
+  });
+
+  test('falls back to exponential backoff when Retry-After is missing or invalid', () => {
+    expect(resolveRetryDelayMs(null, 0, base)).toBe(1000);
+    expect(resolveRetryDelayMs(null, 2, base)).toBe(4000);
+    expect(resolveRetryDelayMs('', 1, base)).toBe(2000);
+    expect(resolveRetryDelayMs('not-a-number', 1, base)).toBe(2000);
+    expect(resolveRetryDelayMs('-3', 0, base)).toBe(1000);
+  });
+});
+
+test.describe('shouldRetryAsRateLimit', () => {
+  test('always retries 429', () => {
+    expect(shouldRetryAsRateLimit(429, new Headers())).toBe(true);
+  });
+
+  test('retries 403 only with rate-limit headers', () => {
+    expect(shouldRetryAsRateLimit(403, new Headers())).toBe(false);
+    expect(
+      shouldRetryAsRateLimit(403, new Headers({ 'Retry-After': '10' })),
+    ).toBe(true);
+    expect(
+      shouldRetryAsRateLimit(
+        403,
+        new Headers({ 'X-RateLimit-Remaining': '0' }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryAsRateLimit(
+        403,
+        new Headers({ 'X-RateLimit-Remaining': '5' }),
+      ),
+    ).toBe(false);
+  });
+
+  test('does not treat other statuses as rate limits', () => {
+    expect(shouldRetryAsRateLimit(401, new Headers())).toBe(false);
+    expect(
+      shouldRetryAsRateLimit(500, new Headers({ 'Retry-After': '1' })),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

GraphQL fetch treated every HTTP 403 like a rate limit and retried it. Permission denials and abuse responses are not rate limits, so those retries delayed real failures and burned quota.

`Retry-After` was also turned into a delay with unguarded `parseInt(...) * 1000`, which can yield `NaN` and break the sleep path.

## Change

- Always retry on **429**.
- Retry on **403** only when rate-limit signals are present: `Retry-After` or `X-RateLimit-Remaining: 0`.
- Resolve delay via `resolveRetryDelayMs`: valid non-negative `Retry-After` (seconds) → ms; otherwise exponential backoff.
- Pure helpers live next to the existing rate-limit message check; unit coverage in `tests/bulk-actions.spec.ts`.

## How verified

- `npx eslint src/relay/environment.ts src/utils/rateLimitError.ts tests/bulk-actions.spec.ts`
- `npx playwright test tests/bulk-actions.spec.ts` (7 passed)

Finding: `relay-403-rate-limit-only`