### PR TITLE
fix(security): verify GitHub PAT before minting session cookie

### DIFF
--- a/src/pages/api/auth/pat.ts
+++ b/src/pages/api/auth/pat.ts
@@ -48,6 +48,38 @@ export async function POST({ request }: { request: Request }) {
     );
   }
 
+  // Verify with GitHub before minting a session so invalid/expired tokens
+  // fail at login instead of causing opaque 401/logout loops later.
+  let probe: Response;
+  try {
+    probe = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  } catch {
+    return new Response(
+      'Could not reach GitHub to verify the token. Please try again in a moment.',
+      { status: 503 },
+    );
+  }
+
+  if (probe.status === 401 || probe.status === 403) {
+    return new Response(
+      'GitHub rejected this token (invalid, expired, or insufficient access). Check the PAT and try again.',
+      { status: 401 },
+    );
+  }
+
+  if (!probe.ok) {
+    return new Response(
+      `GitHub returned status ${probe.status} while verifying the token. Please try again.`,
+      { status: 502 },
+    );
+  }
+
   const secret = new TextEncoder().encode(secretValue);
   const session = await signSessionJwt(
     {


### PR DESCRIPTION
## Summary

PAT login only checked that the token looked like a token (`/^[A-Za-z0-9_.-]+$/`), then minted a session JWT. Bad tokens passed login and blew up later as 401s / logout loops.

Before `signSessionJwt`, this now does `GET https://api.github.com/user` with the same Accept / API-version headers used in `AuthService.probeTokenCapability`.

| Outcome | Response | Session cookie |
| --- | --- | --- |
| 401 / 403 from GitHub | 401 + clear message | not set |
| other non-OK | 502 | not set |
| network failure | 503 | not set |
| OK | existing success + cookie | set as before |

**Behavior change:** invalid PATs fail at login instead of getting a session.

## Test plan

- [ ] Paste a known-good PAT → login still sets the session cookie and reaches the app
- [ ] Paste garbage / revoked PAT → 401, no `Set-Cookie`
- [ ] Offline / blocked GitHub → 503, no session

Finding: `pat-verify-github`