### PR TITLE
fix(auth): restrict OAuth mode query param to read|write

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -53,11 +53,14 @@ export async function GET({ request }: { request: Request }) {
   // This keeps CSRF protection even when preview host differences drop cookies.
   const secret = new TextEncoder().encode(import.meta.env.SESSION_SECRET);
   let nonceFromParamToken: string;
-  let mode: string;
+  let mode: 'read' | 'write';
 
   try {
     const { payload } = await jwtVerify(stateTokenFromParam, secret);
-    if (typeof payload.nonce !== 'string' || typeof payload.mode !== 'string') {
+    if (
+      typeof payload.nonce !== 'string' ||
+      (payload.mode !== 'read' && payload.mode !== 'write')
+    ) {
       throw new Error('Invalid JWT payload');
     }
     nonceFromParamToken = payload.nonce;

--- a/src/pages/api/auth/github.ts
+++ b/src/pages/api/auth/github.ts
@@ -23,7 +23,15 @@ export async function GET({ request }: { request: Request }) {
     );
   }
 
-  const mode = requestUrl.searchParams.get('mode') || 'read';
+  // Only 'read' | 'write' are valid OAuth modes. Missing → 'read'.
+  // Present-but-invalid → 400 so arbitrary values never enter the state JWT.
+  const modeParam = requestUrl.searchParams.get('mode');
+  if (modeParam !== null && modeParam !== 'read' && modeParam !== 'write') {
+    return new Response("Invalid mode: must be 'read' or 'write'.", {
+      status: 400,
+    });
+  }
+  const mode: 'read' | 'write' = modeParam === 'write' ? 'write' : 'read';
 
   // 🛡️ SENTINEL: Generate a random nonce to embed in signed state.
   const randomBytes = new Uint8Array(32);


### PR DESCRIPTION
## Summary
- Allowlist `mode` on `/api/auth/github` to `'read' | 'write'` only.
- **Choice:** missing `mode` defaults to `'read'`; present-but-invalid values return **400** (does not coerce), so arbitrary strings never enter the OAuth state JWT or session claims.
- Defense-in-depth in `/api/auth/callback`: JWT `mode` must be exactly `'read'` or `'write'` before it is stored in the session.

## Why
Previously `mode` was any string from the query (`searchParams.get('mode') || 'read'`), signed into the state JWT and later written into session claims. Only `=== 'write'` branched scopes; other values polluted claims.

## Test plan
- [ ] `GET /api/auth/github` (no mode) → redirects with read scopes; state JWT has `mode: "read"`
- [ ] `GET /api/auth/github?mode=write` → write scopes
- [ ] `GET /api/auth/github?mode=read` → read scopes
- [ ] `GET /api/auth/github?mode=admin` (or any other value) → **400**
- [ ] Successful OAuth callback still sets session with only `read`/`write` mode

Finding: `oauth-mode-enum`