### PR TITLE
fix(ui): use public/logo.svg in Logo component

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -5,36 +5,12 @@ interface LogoProps {
 
 export function Logo({ className = '', size = 32 }: LogoProps) {
   return (
-    <svg
+    <img
+      src="/logo.svg"
+      alt="Margea"
       width={size}
       height={size}
-      viewBox="0 0 100 100"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={className}
-    >
-      {/* Ocean wave background */}
-      <circle cx="50" cy="50" r="48" fill="currentColor" opacity="0.1" />
-
-      {/* Stylized 'M' representing waves/tides */}
-      <path
-        d="M 20 65 L 20 35 L 35 50 L 50 35 L 65 50 L 80 35 L 80 65"
-        stroke="currentColor"
-        strokeWidth="6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-      />
-
-      {/* Bottom wave accent */}
-      <path
-        d="M 15 75 Q 30 70, 50 75 T 85 75"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        fill="none"
-        opacity="0.6"
-      />
-    </svg>
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Replace large inline SVG in `src/components/Logo.tsx` with `<img src="/logo.svg">` so the component uses the existing `public/logo.svg` asset (already used as favicon).
- Keeps the public API stable: `className` and `size` still apply; callers (`Header`, `LoginPage`) need no changes.
- Aligns with AGENTS.md: "Don't ever inline icons".

## Finding
- **id:** `logo-use-public-svg`
- **taxonomy:** AGENTS guideline deviation / duplication

## Test plan
- [x] Prettier check on touched file
- [x] ESLint on touched file
- [ ] Visual: Header logo (`size={22}`) and Login logo (`size={48}`) still size correctly
- [ ] CI green after any parallel prettier fix lands