### PR TITLE
fix(security): validate session JWT payload in /api/auth/token

### DIFF
--- a/src/pages/api/auth/token.ts
+++ b/src/pages/api/auth/token.ts
@@ -1,6 +1,30 @@
-import { jwtVerify } from 'jose';
+import { jwtVerify, type JWTPayload } from 'jose';
 import { parse } from 'cookie';
 import { reportError } from '../../../utils/errorReporting';
+
+/** Session claims returned to the client after successful JWT verify. */
+export type SessionAuthClaims = {
+  token: string;
+  mode: 'read' | 'write';
+};
+
+/**
+ * Validate JWT payload shape for /api/auth/token.
+ * Returns null when claims are unusable (caller should treat as invalid session).
+ */
+export function sessionAuthFromJwtPayload(
+  payload: JWTPayload,
+): SessionAuthClaims | null {
+  const githubToken = payload.github_token;
+  if (typeof githubToken !== 'string' || githubToken.length === 0) {
+    return null;
+  }
+
+  // Login-time label only; coerce anything other than write → read.
+  const mode: 'read' | 'write' = payload.mode === 'write' ? 'write' : 'read';
+
+  return { token: githubToken, mode };
+}
 
 export async function GET({ request }: { request: Request }) {
   // Parse cookies from header
@@ -36,13 +60,17 @@ export async function GET({ request }: { request: Request }) {
   try {
     const secret = new TextEncoder().encode(import.meta.env.SESSION_SECRET);
     const { payload } = await jwtVerify(sessionCookie, secret);
+    const claims = sessionAuthFromJwtPayload(payload);
+    if (!claims) {
+      throw new Error('Invalid session payload');
+    }
 
     return new Response(
       JSON.stringify({
-        token: payload.github_token,
+        token: claims.token,
         // Login-time label only (which OAuth path / PAT entry); client derives
         // real write capability from live token scopes (X-OAuth-Scopes), not this.
-        mode: payload.mode || 'read',
+        mode: claims.mode,
       }),
       {
         headers: {

--- a/tests/auth-token-payload.spec.ts
+++ b/tests/auth-token-payload.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { sessionAuthFromJwtPayload } from '../src/pages/api/auth/token';
+
+test.describe('sessionAuthFromJwtPayload', () => {
+  test('accepts non-empty github_token with write mode', () => {
+    expect(
+      sessionAuthFromJwtPayload({ github_token: 'gho_abc', mode: 'write' }),
+    ).toEqual({ token: 'gho_abc', mode: 'write' });
+  });
+
+  test('accepts read mode', () => {
+    expect(
+      sessionAuthFromJwtPayload({ github_token: 'gho_abc', mode: 'read' }),
+    ).toEqual({ token: 'gho_abc', mode: 'read' });
+  });
+
+  test('defaults missing mode to read', () => {
+    expect(sessionAuthFromJwtPayload({ github_token: 'gho_abc' })).toEqual({
+      token: 'gho_abc',
+      mode: 'read',
+    });
+  });
+
+  test('coerces unknown mode strings to read', () => {
+    expect(
+      sessionAuthFromJwtPayload({ github_token: 'gho_abc', mode: 'admin' }),
+    ).toEqual({ token: 'gho_abc', mode: 'read' });
+  });
+
+  test('rejects missing github_token', () => {
+    expect(sessionAuthFromJwtPayload({ mode: 'read' })).toBeNull();
+  });
+
+  test('rejects empty github_token', () => {
+    expect(
+      sessionAuthFromJwtPayload({ github_token: '', mode: 'write' }),
+    ).toBeNull();
+  });
+
+  test('rejects non-string github_token', () => {
+    expect(
+      sessionAuthFromJwtPayload({ github_token: 12345 as unknown as string }),
+    ).toBeNull();
+    expect(
+      sessionAuthFromJwtPayload({
+        github_token: { nested: true } as unknown as string,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- After `jwtVerify`, require `github_token` to be a non-empty string before returning it to the client.
- Coerce `mode` to `'read' | 'write'` only (unknown/missing → `'read'`).
- Invalid payload shape follows the same path as verify failure: **401** `{ error: 'Invalid session' }` with no partial claims leaked.
- Unit tests for `sessionAuthFromJwtPayload`.

## Finding
`token-payload-validate` — missing validation / security hygiene on session JWT claims.

## Test plan
- [x] `npx playwright test tests/auth-token-payload.spec.ts` (7 passed)
- [x] prettier + eslint on touched files
- [ ] CI Autorelease green after prettier debt lands on main