### PR TITLE
style: apply prettier to files failing CI

### DIFF
--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -20,10 +20,7 @@ import { reportError } from '../utils/errorReporting';
 import { PRGroup } from '../types';
 import { URL_SEARCH_PARAMS } from '../constants';
 import { parseSortStrategy } from '../services/prSort';
-import {
-  parseGroupingStrategy,
-  parsePRState,
-} from '../services/urlParams';
+import { parseGroupingStrategy, parsePRState } from '../services/urlParams';
 import { PRListStats } from './PRListStats';
 import { PRListFilters } from './PRListFilters';
 import { usePRContext } from '../context/PRContext';

--- a/tests/auth-session-cache.spec.ts
+++ b/tests/auth-session-cache.spec.ts
@@ -153,5 +153,4 @@ test.describe('AuthService session token cache', () => {
     expect(await AuthService.getToken()).toBe('recovered');
     expect(tokenCalls).toBe(2);
   });
-
 });

--- a/tests/pr-filter.spec.ts
+++ b/tests/pr-filter.spec.ts
@@ -17,8 +17,7 @@ function makePR(
     };
   } = {},
 ): PullRequest {
-  const nameWithOwner =
-    overrides.repository?.nameWithOwner ?? 'acme/app';
+  const nameWithOwner = overrides.repository?.nameWithOwner ?? 'acme/app';
   const [defaultOwner, defaultName] = nameWithOwner.includes('/')
     ? nameWithOwner.split('/')
     : ['acme', nameWithOwner];

--- a/tests/pr-grouping.spec.ts
+++ b/tests/pr-grouping.spec.ts
@@ -196,9 +196,7 @@ test.describe('groupPullRequests — renovate (default)', () => {
     ];
     const groups = groupPullRequests(prs);
     expect(groups).toHaveLength(1);
-    expect(groups[0].package).toBe(
-      'chore(deps): update dependency foo to v1',
-    );
+    expect(groups[0].package).toBe('chore(deps): update dependency foo to v1');
   });
 
   test('falls back to renovate for unknown strategy', () => {
@@ -216,9 +214,7 @@ test.describe('groupPullRequests — renovate (default)', () => {
     // Cast: runtime path for invalid strategy values
     const groups = groupPullRequests(prs, 'not-a-strategy' as 'renovate');
     expect(groups).toHaveLength(1);
-    expect(groups[0].package).toBe(
-      'chore(deps): update dependency bar to v2',
-    );
+    expect(groups[0].package).toBe('chore(deps): update dependency bar to v2');
   });
 });
 

--- a/tests/url-params.spec.ts
+++ b/tests/url-params.spec.ts
@@ -1,8 +1,5 @@
 import { test, expect } from '@playwright/test';
-import {
-  parseGroupingStrategy,
-  parsePRState,
-} from '../src/services/urlParams';
+import { parseGroupingStrategy, parsePRState } from '../src/services/urlParams';
 import { GROUPING_STRATEGIES, PR_STATES } from '../src/constants';
 
 test.describe('parsePRState', () => {


### PR DESCRIPTION
## Problem
Main Autorelease CI is red because `npx prettier --check .` fails on 5 files. Every PR/push runs `mise run ci` after codegen via `.github/workflows/autorelease.yml`, so Autorelease stays blocked until formatting is fixed.

## Change
Ran `npx prettier --write` on exactly the failing paths (whitespace/line-wrap only, no logic changes):

- `src/components/PRList.tsx`
- `tests/auth-session-cache.spec.ts`
- `tests/pr-filter.spec.ts`
- `tests/pr-grouping.spec.ts`
- `tests/url-params.spec.ts`

Net ~5 lines (collapses multi-line imports/expects to single line).

## Verify
- `npx prettier --check .` — green
- `npx eslint .` — green
- `mise run ci` — lint green; 3 pre-existing routing e2e failures on `tests/routing-test.spec.ts` (404 on SPA refresh) unrelated to this whitespace diff

## Finding
`ci-prettier-green` — unblock Autorelease on main.