### PR TITLE
fix(auth): stop sending ignored mode on PAT login

### DIFF
--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -58,7 +58,6 @@ export function LoginPage() {
         },
         body: JSON.stringify({
           token,
-          mode: 'write',
         }),
       });
 


### PR DESCRIPTION
## Summary
- PAT login POST body included `mode: 'write'`, but `/api/auth/pat` ignores client mode and hardcodes `mode: 'read'` (capability comes from GitHub scopes).
- Send only `token` so the client matches the server contract.

## Test plan
- [ ] Typecheck/lint clean
- [ ] PAT login still posts to `/api/auth/pat` with `{ token }` only
- [ ] No tests asserted the old body field

finding: pat-drop-ignored-mode