### PR TITLE
refactor(auth): build Set-Cookie via cookie.serialize

### DIFF
--- a/src/pages/api/auth/cookies.ts
+++ b/src/pages/api/auth/cookies.ts
@@ -1,3 +1,4 @@
+import { serialize } from 'cookie';
 import { SignJWT } from 'jose';
 
 /** Session cookie / JWT TTL: 7 days. */
@@ -8,27 +9,47 @@ export const SESSION_JWT_EXPIRATION = '7d';
 export const OAUTH_STATE_MAX_AGE_SECONDS = 300;
 
 export function buildSessionCookie(token: string, isHttps: boolean): string {
-  return `session=${token}; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=${SESSION_MAX_AGE_SECONDS}; Path=/`;
+  return serialize('session', token, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+    secure: isHttps,
+  });
 }
 
 export function clearSessionCookie(isHttps: boolean): string {
-  return `session=; HttpOnly; ${isHttps ? 'Secure; ' : ''}SameSite=Strict; Max-Age=0; Path=/`;
+  return serialize('session', '', {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    maxAge: 0,
+    secure: isHttps,
+  });
 }
 
 export function buildOAuthStateCookie(
   stateToken: string,
   isHttps: boolean,
 ): string {
-  return `oauth_state=${stateToken}; HttpOnly; ${
-    isHttps ? 'Secure; ' : ''
-  }Path=/; SameSite=Lax; Max-Age=${OAUTH_STATE_MAX_AGE_SECONDS}`;
+  return serialize('oauth_state', stateToken, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    maxAge: OAUTH_STATE_MAX_AGE_SECONDS,
+    secure: isHttps,
+  });
 }
 
 /** Clears oauth_state with the same attributes used when setting it. */
 export function clearOAuthStateCookie(isHttps: boolean): string {
-  return `oauth_state=; HttpOnly; ${
-    isHttps ? 'Secure; ' : ''
-  }Path=/; SameSite=Lax; Max-Age=0`;
+  return serialize('oauth_state', '', {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    maxAge: 0,
+    secure: isHttps,
+  });
 }
 
 export async function signSessionJwt(

--- a/tests/oauth-state-cookie.spec.ts
+++ b/tests/oauth-state-cookie.spec.ts
@@ -1,38 +1,104 @@
 import { test, expect } from '@playwright/test';
 import {
+  SESSION_MAX_AGE_SECONDS,
+  OAUTH_STATE_MAX_AGE_SECONDS,
+  buildSessionCookie,
+  clearSessionCookie,
   buildOAuthStateCookie,
   clearOAuthStateCookie,
 } from '../src/pages/api/auth/cookies';
 
+/** Parse Set-Cookie attributes into a map for order-independent checks. */
+function cookieAttrs(header: string): {
+  name: string;
+  value: string;
+  flags: Set<string>;
+  attrs: Record<string, string>;
+} {
+  const parts = header.split(';').map((p) => p.trim());
+  const [nameValue, ...rest] = parts;
+  const eq = nameValue.indexOf('=');
+  const name = eq === -1 ? nameValue : nameValue.slice(0, eq);
+  const value = eq === -1 ? '' : nameValue.slice(eq + 1);
+  const flags = new Set<string>();
+  const attrs: Record<string, string> = {};
+  for (const part of rest) {
+    const i = part.indexOf('=');
+    if (i === -1) {
+      flags.add(part.toLowerCase());
+    } else {
+      attrs[part.slice(0, i).toLowerCase()] = part.slice(i + 1);
+    }
+  }
+  return { name, value, flags, attrs };
+}
+
 test.describe('oauth_state cookie helpers', () => {
-  test('clear uses same Secure/SameSite/Path/HttpOnly as set when HTTPS', () => {
-    const set = buildOAuthStateCookie('token', true);
-    const clear = clearOAuthStateCookie(true);
+  test('set/clear share Secure/SameSite/Path/HttpOnly when HTTPS', () => {
+    const set = cookieAttrs(buildOAuthStateCookie('token', true));
+    const clear = cookieAttrs(clearOAuthStateCookie(true));
 
-    expect(set).toContain('Secure');
-    expect(set).toContain('SameSite=Lax');
-    expect(set).toContain('HttpOnly');
-    expect(set).toContain('Path=/');
+    expect(set.name).toBe('oauth_state');
+    expect(set.value).toBe('token');
+    expect(set.flags.has('secure')).toBe(true);
+    expect(set.flags.has('httponly')).toBe(true);
+    expect(set.attrs.path).toBe('/');
+    expect(set.attrs.samesite).toBe('Lax');
+    expect(set.attrs['max-age']).toBe(String(OAUTH_STATE_MAX_AGE_SECONDS));
 
-    expect(clear).toBe(
-      'oauth_state=; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=0',
-    );
-    expect(clear).toContain('Secure');
-    expect(clear).toContain('SameSite=Lax');
-    expect(clear).toContain('HttpOnly');
-    expect(clear).toContain('Path=/');
-    expect(clear).toContain('Max-Age=0');
+    expect(clear.name).toBe('oauth_state');
+    expect(clear.value).toBe('');
+    expect(clear.flags.has('secure')).toBe(true);
+    expect(clear.flags.has('httponly')).toBe(true);
+    expect(clear.attrs.path).toBe('/');
+    expect(clear.attrs.samesite).toBe('Lax');
+    expect(clear.attrs['max-age']).toBe('0');
   });
 
   test('clear omits Secure when not HTTPS, still matches set attrs', () => {
-    const set = buildOAuthStateCookie('token', false);
-    const clear = clearOAuthStateCookie(false);
+    const set = cookieAttrs(buildOAuthStateCookie('token', false));
+    const clear = cookieAttrs(clearOAuthStateCookie(false));
 
-    expect(set).not.toContain('Secure');
-    expect(clear).toBe(
-      'oauth_state=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0',
-    );
-    expect(clear).not.toContain('Secure');
-    expect(clear).toContain('SameSite=Lax');
+    expect(set.flags.has('secure')).toBe(false);
+    expect(clear.flags.has('secure')).toBe(false);
+    expect(clear.flags.has('httponly')).toBe(true);
+    expect(clear.attrs.path).toBe('/');
+    expect(clear.attrs.samesite).toBe('Lax');
+    expect(clear.attrs['max-age']).toBe('0');
+  });
+});
+
+test.describe('session cookie helpers', () => {
+  test('set/clear share Secure/SameSite/Path/HttpOnly when HTTPS', () => {
+    const set = cookieAttrs(buildSessionCookie('jwt.token.value', true));
+    const clear = cookieAttrs(clearSessionCookie(true));
+
+    expect(set.name).toBe('session');
+    expect(set.value).toBe('jwt.token.value');
+    expect(set.flags.has('secure')).toBe(true);
+    expect(set.flags.has('httponly')).toBe(true);
+    expect(set.attrs.path).toBe('/');
+    expect(set.attrs.samesite).toBe('Strict');
+    expect(set.attrs['max-age']).toBe(String(SESSION_MAX_AGE_SECONDS));
+
+    expect(clear.name).toBe('session');
+    expect(clear.value).toBe('');
+    expect(clear.flags.has('secure')).toBe(true);
+    expect(clear.flags.has('httponly')).toBe(true);
+    expect(clear.attrs.path).toBe('/');
+    expect(clear.attrs.samesite).toBe('Strict');
+    expect(clear.attrs['max-age']).toBe('0');
+  });
+
+  test('omits Secure when not HTTPS', () => {
+    const set = cookieAttrs(buildSessionCookie('tok', false));
+    const clear = cookieAttrs(clearSessionCookie(false));
+
+    expect(set.flags.has('secure')).toBe(false);
+    expect(clear.flags.has('secure')).toBe(false);
+    expect(set.attrs.samesite).toBe('Strict');
+    expect(clear.attrs.samesite).toBe('Strict');
+    expect(set.attrs['max-age']).toBe(String(SESSION_MAX_AGE_SECONDS));
+    expect(clear.attrs['max-age']).toBe('0');
   });
 });


### PR DESCRIPTION
## Summary

- Use `cookie.serialize` for `buildSessionCookie`, `clearSessionCookie`, `buildOAuthStateCookie`, and `clearOAuthStateCookie` instead of hand-rolled Set-Cookie strings.
- Preserves attribute semantics: session uses HttpOnly, Path=/, SameSite=Strict, Secure when HTTPS, Max-Age SESSION / 0; oauth_state uses SameSite=Lax and OAuth TTL / 0.
- Exported function signatures unchanged; callers (callback/logout/pat/github) untouched.
- Extends unit tests for order-independent attribute parity on both session and oauth_state cookies.

`cookie` is already a dependency and was only used for `parse`. Hand-rolled attribute strings previously caused set/clear mismatches.

Finding: `cookie-use-serialize`

## Test plan

- [x] `npx playwright test tests/oauth-state-cookie.spec.ts` (4 passed)
- [ ] CI green on this PR