### PR TITLE
fix: stop fake 5000/5000 rate-limit defaults

### DIFF
--- a/src/components/RateLimitIndicator.tsx
+++ b/src/components/RateLimitIndicator.tsx
@@ -71,15 +71,23 @@ export function RateLimitIndicator({
   const [state, setState] = useState<RateLimitState>(rateLimitStore.getState());
   const [timeUntilReset, setTimeUntilReset] = useState<string>('');
   const isWrite = currentMode === 'write';
+  const isKnown =
+    state.limit !== null && state.remaining !== null && state.reset !== null;
 
   useEffect(() => {
     return rateLimitStore.subscribe(setState);
   }, []);
 
   useEffect(() => {
+    const resetAt = state.reset;
+    if (resetAt === null) {
+      setTimeUntilReset('—');
+      return;
+    }
+
     const updateTimer = () => {
       const now = Date.now() / 1000;
-      const diff = state.reset - now;
+      const diff = resetAt - now;
 
       if (diff <= 0) {
         setTimeUntilReset('Now');
@@ -96,24 +104,34 @@ export function RateLimitIndicator({
     return () => clearInterval(interval);
   }, [state.reset]);
 
+  const limit = state.limit;
+  const remaining = state.remaining;
   const percentage =
-    state.limit > 0
+    limit !== null && remaining !== null && limit > 0
       ? Math.min(
           100,
-          Math.max(0, Math.round((state.remaining / state.limit) * 100)),
+          Math.max(0, Math.round((remaining / limit) * 100)),
         )
       : 0;
 
-  let colorClass = 'text-success';
-  if (percentage < 20) colorClass = 'text-error';
-  else if (percentage < 50) colorClass = 'text-warning';
+  let colorClass = 'text-base-content/40';
+  if (isKnown) {
+    colorClass = 'text-success';
+    if (percentage < 20) colorClass = 'text-error';
+    else if (percentage < 50) colorClass = 'text-warning';
+  }
 
-  const progressClass =
-    percentage < 20
+  const progressClass = !isKnown
+    ? ''
+    : percentage < 20
       ? 'progress-error'
       : percentage < 50
         ? 'progress-warning'
         : 'progress-success';
+
+  const remainingLabel = isKnown
+    ? `${state.remaining} / ${state.limit}`
+    : '—';
 
   return (
     <div className="dropdown dropdown-end">
@@ -208,14 +226,21 @@ export function RateLimitIndicator({
             <span
               className={`font-mono font-semibold tabular-nums ${colorClass}`}
             >
-              {state.remaining} / {state.limit}
+              {remainingLabel}
             </span>
           </div>
-          <progress
-            className={`progress w-full h-1.5 ${progressClass}`}
-            value={percentage}
-            max={100}
-          />
+          {isKnown ? (
+            <progress
+              className={`progress w-full h-1.5 ${progressClass}`}
+              value={percentage}
+              max={100}
+            />
+          ) : (
+            <div
+              className="h-1.5 w-full rounded-full bg-base-300"
+              aria-hidden
+            />
+          )}
           <div className="flex justify-between items-center text-xs">
             <span className="text-base-content/60">
               {t('rateLimit.resetsIn')}

--- a/src/services/rateLimitStore.ts
+++ b/src/services/rateLimitStore.ts
@@ -1,17 +1,24 @@
 export interface RateLimitState {
-  limit: number;
-  remaining: number;
-  reset: number; // Unix timestamp in seconds
+  limit: number | null;
+  remaining: number | null;
+  reset: number | null; // Unix timestamp in seconds
 }
 
 type Listener = (state: RateLimitState) => void;
 
-class RateLimitStore {
-  private state: RateLimitState = {
-    limit: 5000,
-    remaining: 5000,
-    reset: Date.now() / 1000 + 3600, // Default to 1 hour from now
-  };
+const UNKNOWN_STATE: RateLimitState = {
+  limit: null,
+  remaining: null,
+  reset: null,
+};
+
+function parseHeaderInt(value: string): number | null {
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export class RateLimitStore {
+  private state: RateLimitState = { ...UNKNOWN_STATE };
   private listeners: Set<Listener> = new Set();
 
   getState() {
@@ -21,10 +28,22 @@ class RateLimitStore {
   update(limit: string | null, remaining: string | null, reset: string | null) {
     if (!limit || !remaining || !reset) return;
 
+    const parsedLimit = parseHeaderInt(limit);
+    const parsedRemaining = parseHeaderInt(remaining);
+    const parsedReset = parseHeaderInt(reset);
+
+    if (
+      parsedLimit === null ||
+      parsedRemaining === null ||
+      parsedReset === null
+    ) {
+      return;
+    }
+
     this.state = {
-      limit: parseInt(limit, 10),
-      remaining: parseInt(remaining, 10),
-      reset: parseInt(reset, 10),
+      limit: parsedLimit,
+      remaining: parsedRemaining,
+      reset: parsedReset,
     };
 
     this.notify();

--- a/tests/rate-limit-store.spec.ts
+++ b/tests/rate-limit-store.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+import { RateLimitStore } from '../src/services/rateLimitStore';
+
+test.describe('RateLimitStore', () => {
+  test('starts unknown (null) instead of fake 5000/5000', () => {
+    const store = new RateLimitStore();
+    expect(store.getState()).toEqual({
+      limit: null,
+      remaining: null,
+      reset: null,
+    });
+  });
+
+  test('update ignores missing headers', () => {
+    const store = new RateLimitStore();
+    store.update(null, '10', '100');
+    store.update('5000', null, '100');
+    store.update('5000', '10', null);
+    expect(store.getState()).toEqual({
+      limit: null,
+      remaining: null,
+      reset: null,
+    });
+  });
+
+  test('update rejects non-finite parse results', () => {
+    const store = new RateLimitStore();
+    store.update('not-a-number', '10', '100');
+    store.update('5000', 'NaN', '100');
+    store.update('5000', '10', '');
+    store.update('abc', 'def', 'ghi');
+    expect(store.getState()).toEqual({
+      limit: null,
+      remaining: null,
+      reset: null,
+    });
+  });
+
+  test('update accepts valid headers and notifies', () => {
+    const store = new RateLimitStore();
+    const seen: Array<ReturnType<RateLimitStore['getState']>> = [];
+    store.subscribe((s) => seen.push(s));
+
+    store.update('5000', '4999', '1700000000');
+    expect(store.getState()).toEqual({
+      limit: 5000,
+      remaining: 4999,
+      reset: 1700000000,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual(store.getState());
+  });
+
+  test('invalid update does not clobber known state', () => {
+    const store = new RateLimitStore();
+    store.update('5000', '100', '1700000000');
+    store.update('nope', '100', '1700000000');
+    store.update(null, null, null);
+    expect(store.getState()).toEqual({
+      limit: 5000,
+      remaining: 100,
+      reset: 1700000000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Default rate-limit state is **unknown** (`null` limit/remaining/reset) until the first valid `X-RateLimit-*` headers arrive — no more pretentious 5000/5000 healthy quota.
- `update()` rejects missing headers and non-finite `parseInt` results (`Number.isFinite`), and never clobbers a previously known good state with garbage.
- Indicator shows muted ring, `—` for remaining/reset, and a neutral bar while unknown.

## Test plan
- [x] `npx playwright test tests/rate-limit-store.spec.ts` (5 pure unit tests)
- [ ] Confirm UI does not show green full ring before any GraphQL response
- [ ] After a request, remaining/limit populate from real headers

Finding: `rate-limit-unknown-defaults`