### PR TITLE
fix(spa): serve SPA shell for client deep links so routing tests pass

### DIFF
--- a/src/layouts/SpaShell.astro
+++ b/src/layouts/SpaShell.astro
@@ -1,0 +1,30 @@
+---
+import '../index.css';
+import App from '../App';
+---
+
+<html lang="pt-BR" data-theme="margea-light">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Margea — analyze, group, and act on GitHub PRs, especially Renovate dependency updates."
+    />
+    <title>Margea — GitHub PR Analyzer</title>
+    <script>
+      // Apply theme before paint to avoid flash; migrate legacy light/dark keys
+      const saved = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      let theme = prefersDark ? 'margea-dark' : 'margea-light';
+      if (saved === 'margea-light' || saved === 'margea-dark') theme = saved;
+      else if (saved === 'light') theme = 'margea-light';
+      else if (saved === 'dark') theme = 'margea-dark';
+      document.documentElement.setAttribute('data-theme', theme);
+    </script>
+  </head>
+  <body>
+    <App client:only="react" />
+  </body>
+</html>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,0 +1,11 @@
+---
+/**
+ * Catch-all SPA shell for client-side routes (React Router).
+ * Serves the same document as index so hard refresh / deep links
+ * (e.g. /orgs, /org/:owner, /:owner/:repo) work under `astro dev`
+ * and SSR. More specific routes under pages/api/** still take priority.
+ */
+import SpaShell from '../layouts/SpaShell.astro';
+---
+
+<SpaShell />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,30 +1,5 @@
 ---
-import '../index.css';
-import App from '../App';
+import SpaShell from '../layouts/SpaShell.astro';
 ---
 
-<html lang="pt-BR" data-theme="margea-light">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Margea — analyze, group, and act on GitHub PRs, especially Renovate dependency updates."
-    />
-    <title>Margea — GitHub PR Analyzer</title>
-    <script>
-      // Apply theme before paint to avoid flash; migrate legacy light/dark keys
-      const saved = localStorage.getItem('theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      let theme = prefersDark ? 'margea-dark' : 'margea-light';
-      if (saved === 'margea-light' || saved === 'margea-dark') theme = saved;
-      else if (saved === 'light') theme = 'margea-light';
-      else if (saved === 'dark') theme = 'margea-dark';
-      document.documentElement.setAttribute('data-theme', theme);
-    </script>
-  </head>
-  <body>
-    <App client:only="react" />
-  </body>
-</html>
+<SpaShell />


### PR DESCRIPTION
## Summary
- Hard refresh of client routes (`/orgs`, `/org/:owner`, `/:owner/:repo`) returned Astro `404: Not Found` before React Router could run.
- CI uses `npm run dev` / `astro dev`, so a Vercel rewrite alone is not enough for green Playwright routing tests.
- Extract shared SPA shell into `src/layouts/SpaShell.astro` and add `src/pages/[...slug].astro` catch-all that renders the same shell as `/`.
- `pages/api/**` endpoints stay more specific and continue to work (verified `/api/auth/token` still 401 without session).

## Finding
`ci-spa-deep-link-fallback`

## Test plan
- [x] `npx playwright test tests/routing-test.spec.ts` — 4/4 passed
- [x] `mise run ci` — prettier + eslint + 100 Playwright tests passed
- [x] Manual curl: `/`, `/orgs`, `/org/facebook`, `/facebook/react` → 200 SPA title; `/api/auth/token` → 401 JSON