### PR TITLE
chore(deps): remove unused @sentry/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@sentry/astro": "^10.61.0",
-        "@sentry/react": "^10.61.0",
         "@vercel/node": "^5.5.6",
         "cookie": "^1.1.1",
         "i18next": "^25.6.2",
@@ -3602,22 +3601,6 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
-      }
-    },
-    "node_modules/@sentry/react": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.61.0.tgz",
-      "integrity": "sha512-p1Ay3ZfDONSxU2rnX5sMxvxJ9TUi9XzczTN87lVQ29V/PColaRzmRoYVRfrBjffG17ksxYoYhbqipurJk+45cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.61.0",
-        "@sentry/core": "10.61.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/replay": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@sentry/astro": "^10.61.0",
-    "@sentry/react": "^10.61.0",
     "@vercel/node": "^5.5.6",
     "cookie": "^1.1.1",
     "i18next": "^25.6.2",


### PR DESCRIPTION
## Summary
- Remove unused `@sentry/react` dependency from `package.json` / lockfile.
- App only imports `@sentry/astro` (`errorReporting`, `sentry.*.config`, `astro.config`).

## Finding
- **id:** `drop-unused-sentry-react`
- **taxonomy:** dead-code

## Test plan
- [x] `rg '@sentry/react'` — no code or package refs
- [x] `mise run ci` green (lint + 107 playwright tests)