### PR TITLE
fix(retry): respect AbortSignal during backoff via abortableSleep

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,3 +1,5 @@
+import { abortableSleep, isAbortError } from './abort';
+
 /**
  * Configuration options for the retry mechanism.
  */
@@ -18,6 +20,11 @@ export interface RetryOptions {
    * Useful for logging or updating UI state.
    */
   onRetry?: (attempt: number, delayMs: number, error: unknown) => void;
+  /**
+   * When provided, backoff sleeps respect this signal so cancel can
+   * interrupt retries without waiting for the full delay.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -38,6 +45,7 @@ export async function executeWithRetry<T>(
     backoffFactor = 2,
     shouldRetry = () => true,
     onRetry,
+    signal,
   } = options;
 
   let retries = 0;
@@ -46,7 +54,7 @@ export async function executeWithRetry<T>(
     try {
       return await operation();
     } catch (error) {
-      if (retries >= maxRetries || !shouldRetry(error)) {
+      if (isAbortError(error) || retries >= maxRetries || !shouldRetry(error)) {
         throw error;
       }
 
@@ -57,7 +65,7 @@ export async function executeWithRetry<T>(
         onRetry(retries, delayMs, error);
       }
 
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await abortableSleep(delayMs, signal);
     }
   }
 }

--- a/tests/retry.spec.ts
+++ b/tests/retry.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { executeWithRetry } from '../src/utils/retry';
+import { isAbortError } from '../src/utils/abort';
 
 test.describe('executeWithRetry', () => {
   test('should execute operation successfully without retries', async () => {
@@ -102,6 +103,66 @@ test.describe('executeWithRetry', () => {
       // Initial delay 50. retry 0 -> delay 50 * 2^0 = 50.
       expect(onRetryCalls.length).toBe(1);
       expect(onRetryCalls[0]).toBe(50);
+    });
+  });
+
+  test('should abort during backoff when signal is aborted', async () => {
+    await test.step('Abort interrupts sleep', async () => {
+      let attempts = 0;
+      const controller = new AbortController();
+      const operation = async () => {
+        attempts++;
+        throw new Error('fail');
+      };
+
+      const started = Date.now();
+      // Abort shortly after first failure enters a long backoff
+      const abortTimer = setTimeout(() => controller.abort(), 40);
+      let caught: unknown;
+      try {
+        await executeWithRetry(operation, {
+          maxRetries: 5,
+          initialDelayMs: 10_000,
+          backoffFactor: 1,
+          signal: controller.signal,
+        });
+        throw new Error('expected executeWithRetry to reject');
+      } catch (err) {
+        caught = err;
+      } finally {
+        clearTimeout(abortTimer);
+      }
+
+      expect(isAbortError(caught)).toBe(true);
+      expect(attempts).toBe(1);
+      // Must not wait for the full 10s backoff
+      expect(Date.now() - started).toBeLessThan(2000);
+    });
+  });
+
+  test('should not retry when operation throws AbortError', async () => {
+    await test.step('AbortError is terminal', async () => {
+      let attempts = 0;
+      const operation = async () => {
+        attempts++;
+        const err = new Error('Aborted');
+        err.name = 'AbortError';
+        throw err;
+      };
+
+      let caught: unknown;
+      try {
+        await executeWithRetry(operation, {
+          maxRetries: 3,
+          initialDelayMs: 50,
+        });
+        throw new Error('expected executeWithRetry to reject');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(isAbortError(caught)).toBe(true);
+      expect(attempts).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `signal?: AbortSignal` to `RetryOptions`
- Sleep between retries with `abortableSleep` so cancel can interrupt backoff
- Rethrow `AbortError` without further retries; default (no signal) unchanged
- Tests: abort during long backoff; operation-thrown AbortError is terminal

Finding: `retry-abort-signal` — bulkActions cancel could not interrupt bare `setTimeout` sleeps; relay already uses `abortableSleep`.

Util-only change; bulk wiring can be a follow-up.

## Test plan
- [x] `mise run ci` (lint + 109 playwright tests)
- [x] New abort-during-backoff coverage in `tests/retry.spec.ts`