### PR TITLE
chore(types): remove unused FilterOptions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,11 +55,6 @@ export interface PRGroup {
   count: number;
 }
 
-export interface FilterOptions {
-  repository?: string;
-  state?: 'OPEN' | 'CLOSED' | 'MERGED' | 'ALL';
-}
-
 export type BulkActionType = 'merge' | 'close';
 
 export type ConfirmBulkActionOptions = {


### PR DESCRIPTION
## Summary
- Deletes the unused `FilterOptions` interface from `src/types/index.ts`.
- It only had `repository`/`state` and was never imported; real filtering uses an inline shape that also covers author/owner.

## Finding
- **id:** `dead-filteroptions-type`
- **taxonomy:** dead-code / type-debt

## Test plan
- [x] `mise run ci` (eslint, prettier, 114 playwright tests)
- [x] `rg FilterOptions` → no remaining references