### PR TITLE
fix(sentry): lower production trace and error-replay sample rates

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration(),
   ],
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.5,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,5 +2,5 @@ import * as Sentry from '@sentry/astro';
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN || import.meta.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
 });


### PR DESCRIPTION
## Summary

Lower Sentry client/server sample rates that were set to `1.0` (full sampling). Full traces and error-session replays are expensive and privacy-heavy for a SPA that holds GitHub tokens in JS.

### Numbers

| Setting | Before | After |
|---------|--------|-------|
| client `tracesSampleRate` | 1.0 | **0.1** |
| client `replaysOnErrorSampleRate` | 1.0 | **0.5** |
| client `replaysSessionSampleRate` | 0.1 | 0.1 (unchanged) |
| server `tracesSampleRate` | 1.0 | **0.1** |

- DSN wiring and integrations (`browserTracingIntegration`, `replayIntegration`) are **unchanged**.
- No env override pattern existed for sample rates; fixed conservative defaults only.
- Server also had `tracesSampleRate: 1.0`, so it was aligned with the client default.

**Finding id:** `sentry-sample-rates`

## Test plan

- [x] `mise run ci` green locally (eslint, prettier, 114 playwright tests)
- [ ] Confirm production Sentry volume drops after deploy (traces ~10%, error replays ~50%)
- [ ] Optionally raise rates via a follow-up if observability needs more signal