### PR TITLE
chore: remove dead PR target constants and orphan prsGoal i18n

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,6 @@ export const PR_STATES = ['ALL', 'OPEN', 'CLOSED', 'MERGED'] as const;
 export type PRState = (typeof PR_STATES)[number];
 
 // PRList constants
-export const DEFAULT_PR_TARGET = 100;
-export const MAX_PR_TARGET = 1000;
 export const BATCH_SIZE = 100;
 
 /** Milliseconds in one day (used for fetch windows and adaptive intervals). */
@@ -33,7 +31,6 @@ export const URL_SEARCH_PARAMS = {
   STATE: 'state',
   AUTHOR: 'author',
   OWNER: 'owner',
-  LIMIT: 'limit',
   GROUP_BY: 'group_by',
   SORT_BY: 'sort_by',
 } as const;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,8 +12,6 @@
     "optional_specify_repository": "Optional: specify a single repository",
     "search_pull_requests": "Search Pull Requests",
     "login_required": "Login required to search",
-    "prsGoal": "PRs Goal",
-    "prsGoalDescription": "The system will automatically search until it reaches this goal (default: 100)",
     "exampleOwner": "ex: facebook",
     "exampleRepo": "ex: react",
     "exampleLimit": "100"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -12,8 +12,6 @@
     "optional_specify_repository": "Opcional: especifique un único repositorio",
     "search_pull_requests": "Buscar Pull Requests",
     "login_required": "Se requiere iniciar sesión para buscar",
-    "prsGoal": "Meta de PRs",
-    "prsGoalDescription": "El sistema buscará automáticamente hasta alcanzar esta meta (por defecto: 100)",
     "exampleOwner": "ej: facebook",
     "exampleRepo": "ej: react",
     "exampleLimit": "100"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -11,9 +11,7 @@
     "repository": "Repositório",
     "optional_specify_repository": "Opcional: especifique um único repositório",
     "search_pull_requests": "Buscar Pull Requests",
-    "login_required": "Login necessário para pesquisar",
-    "prsGoal": "Objetivo de PRs",
-    "prsGoalDescription": "O sistema procurará automaticamente até atingir este objetivo (padrão: 100)"
+    "login_required": "Login necessário para pesquisar"
   },
   "header": {
     "login": "Entrar",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -12,8 +12,6 @@
     "optional_specify_repository": "Opcional: especifique um repositório específico",
     "search_pull_requests": "Buscar Pull Requests",
     "login_required": "Login necessário para buscar",
-    "prsGoal": "Meta de PRs",
-    "prsGoalDescription": "Sistema buscará automaticamente até atingir essa meta (padrão: 100)",
     "exampleOwner": "ex: facebook",
     "exampleRepo": "ex: react",
     "exampleLimit": "100"


### PR DESCRIPTION
## Summary
- Remove unused `DEFAULT_PR_TARGET`, `MAX_PR_TARGET`, and `URL_SEARCH_PARAMS.LIMIT` from `src/constants.ts` (fetch is window-based; only `BATCH_SIZE` remains live).
- Remove orphan `search.prsGoal` / `search.prsGoalDescription` keys from en/es/pt/pt-BR locales (UI no longer exposes a PR goal of 100).

## Finding
- **id:** `dead-pr-target-constants`
- **taxonomy:** dead-code

## Test plan
- [x] `mise run ci` green (eslint, prettier, 114 playwright tests)
- [x] Grep confirms no remaining imports/usages of removed symbols/keys