### PR TITLE
security: enforce write capability in BulkActionsService

### DIFF
--- a/src/services/bulkActions.ts
+++ b/src/services/bulkActions.ts
@@ -6,6 +6,7 @@ import { executeWithRetry } from '../utils/retry';
 import { isRateLimitErrorMessage } from '../utils/rateLimitError';
 import { DEFAULT_MERGE_METHOD } from '../constants';
 import i18n from '../i18n';
+import { AuthService } from './auth';
 import { toPendingProgress } from './bulkProgress';
 import type {
   PullRequest,
@@ -212,6 +213,28 @@ export const BulkActionsService = {
     }
 
     onProgress(Array.from(progressMap.values()));
+
+    // Defense-in-depth: UI also gates on hasWritePermission, but any caller
+    // of this service must not reach GitHub mutations without write mode.
+    const canWrite = await AuthService.hasWritePermission();
+    if (!canWrite) {
+      const error = i18n.t('prGroupDetail.writePermissionRequired');
+      for (const pr of prs) {
+        const result: BulkActionResult = {
+          success: false,
+          prId: pr.id,
+          error,
+        };
+        progressMap.set(pr.id, {
+          ...progressMap.get(pr.id)!,
+          status: 'error',
+          error,
+        });
+        onResult?.(result);
+      }
+      onProgress(Array.from(progressMap.values()));
+      return;
+    }
 
     const performAction =
       actionType === 'merge'


### PR DESCRIPTION
## Summary
- **Finding:** `write-gate-bulk-actions` — UI hides merge/close via `hasWritePermission`, but `executeBulkAction` never checked capability.
- At the start of `BulkActionsService.executeBulkAction`, call `AuthService.hasWritePermission()`.
- If not write: mark every PR as `error` with `prGroupDetail.writePermissionRequired`, invoke `onResult` for each, emit progress, and return **without** calling GitHub.

## Behavior change (callers)
Programmatic callers of `executeBulkAction` (and any path that reaches it without the UI gate) now fail closed when effective mode is not write (read-only preference, read-only token, or unauthenticated).

## Test plan
- [x] `mise run ci` green locally
- [ ] Confirm read-only session cannot complete bulk merge/close via service path
- [ ] Confirm write session still processes bulk actions as before