### PR TITLE
fix(i18n): rate-limit reset countdown strings

### DIFF
--- a/src/components/RateLimitIndicator.tsx
+++ b/src/components/RateLimitIndicator.tsx
@@ -59,13 +59,16 @@ function RateLimitRing({
   );
 }
 
-function formatTimeUntilReset(reset: number | null): string {
+function formatTimeUntilReset(
+  reset: number | null,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
   if (reset === null) return '—';
   const diff = reset - Date.now() / 1000;
-  if (diff <= 0) return 'Now';
+  if (diff <= 0) return t('rateLimit.now');
   const minutes = Math.floor(diff / 60);
   const seconds = Math.floor(diff % 60);
-  return `${minutes}m ${seconds}s`;
+  return t('rateLimit.duration', { minutes, seconds });
 }
 
 export function RateLimitIndicator({
@@ -95,7 +98,7 @@ export function RateLimitIndicator({
     return () => clearInterval(interval);
   }, [state.reset]);
 
-  const timeUntilReset = formatTimeUntilReset(state.reset);
+  const timeUntilReset = formatTimeUntilReset(state.reset, t);
 
   const limit = state.limit;
   const remaining = state.remaining;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -218,6 +218,8 @@
     "title": "GitHub API Quota",
     "remaining": "Remaining:",
     "resetsIn": "Resets in:",
+    "now": "Now",
+    "duration": "{{minutes}}m {{seconds}}s",
     "updates": "Updates automatically on every request"
   },
   "theme": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -222,6 +222,8 @@
     "title": "Cuota de la API de GitHub",
     "remaining": "Restantes:",
     "resetsIn": "Se reinicia en:",
+    "now": "Ahora",
+    "duration": "{{minutes}}m {{seconds}}s",
     "updates": "Se actualiza automáticamente en cada solicitud"
   },
   "theme": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -123,5 +123,9 @@
   },
   "filters": {
     "clear": "Limpar filtros"
+  },
+  "rateLimit": {
+    "now": "Agora",
+    "duration": "{{minutes}}m {{seconds}}s"
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -222,6 +222,8 @@
     "title": "GitHub API Quota",
     "remaining": "Restantes:",
     "resetsIn": "Reseta em:",
+    "now": "Agora",
+    "duration": "{{minutes}}m {{seconds}}s",
     "updates": "Atualiza automaticamente a cada requisição"
   },
   "theme": {


### PR DESCRIPTION
## Problem
`formatTimeUntilReset` in `RateLimitIndicator` returned hardcoded English `"Now"` and `` `${minutes}m ${seconds}s` `` while the rest of the account menu already went through `t()`.

## Change
- Pass `t` into `formatTimeUntilReset` and use `rateLimit.now` / `rateLimit.duration`
- Add keys in `en`, `es`, `pt`, and `pt-BR` locales

## Verify
- `mise run lint` (eslint + prettier)
- `mise run test` — 126 passed