### PR TITLE
refactor(PRList): drop duplicate clear-group handler

### DIFF
--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -169,12 +169,6 @@ function PRListContent() {
     setSearchParams(newParams);
   };
 
-  const handleBackFromGroup = () => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.delete(URL_SEARCH_PARAMS.GROUP);
-    setSearchParams(newParams);
-  };
-
   // Infinite Scroll Sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
   // Disable auto-load if any filter is active
@@ -239,7 +233,7 @@ function PRListContent() {
             />
             <PRGroupDetail
               group={selectedGroup}
-              onBack={handleBackFromGroup}
+              onBack={handleClearGroup}
               onClearGroup={handleClearGroup}
             />
           </div>


### PR DESCRIPTION
## Summary

`handleClearGroup` and `handleBackFromGroup` in `PRList` were the same function: delete the `GROUP` search param and call `setSearchParams`. Two names made it look like different behavior when there was none.

Kept `handleClearGroup` and pass it for both `onBack` and `onClearGroup` on `PRGroupDetail`. No behavior change.

## Test plan

- [ ] Open a PR group detail view
- [ ] Back control clears the group selection (URL loses `group`)
- [ ] Clear-group control does the same
- [ ] Other filters/search params stay as they were