### PR TITLE
fix(a11y): sync html lang with active i18n language

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,10 +6,17 @@ import en from './locales/en.json';
 import es from './locales/es.json';
 import pt from './locales/pt.json';
 
+/** Supported <html lang> tags (resource keys). Longest prefix match wins. */
+const HTML_LANGS = ['en', 'es', 'pt'] as const;
+
 /** Map i18next language codes to BCP-47 tags for <html lang>. */
 function toHtmlLang(lng: string): string {
-  const base = lng.split('-')[0]?.toLowerCase() ?? 'en';
-  if (base === 'en' || base === 'es' || base === 'pt') return base;
+  const lower = lng.toLowerCase();
+  // Longest prefix match wins (e.g. pt-BR before pt if both listed).
+  const byLength = [...HTML_LANGS].sort((a, b) => b.length - a.length);
+  for (const code of byLength) {
+    if (lower === code || lower.startsWith(`${code}-`)) return code;
+  }
   return 'en';
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,7 +6,21 @@ import en from './locales/en.json';
 import es from './locales/es.json';
 import pt from './locales/pt.json';
 
-i18next
+/** Map i18next language codes to BCP-47 tags for <html lang>. */
+function toHtmlLang(lng: string): string {
+  const base = lng.split('-')[0]?.toLowerCase() ?? 'en';
+  if (base === 'en' || base === 'es' || base === 'pt') return base;
+  return 'en';
+}
+
+function syncDocumentLang(lng: string) {
+  if (typeof document === 'undefined') return;
+  document.documentElement.lang = toHtmlLang(lng);
+}
+
+i18next.on('languageChanged', syncDocumentLang);
+
+void i18next
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
@@ -19,6 +33,9 @@ i18next
       es: { translation: es },
       pt: { translation: pt },
     },
+  })
+  .then(() => {
+    syncDocumentLang(i18next.language);
   });
 
 export default i18next;

--- a/src/layouts/SpaShell.astro
+++ b/src/layouts/SpaShell.astro
@@ -3,7 +3,7 @@ import '../index.css';
 import App from '../App';
 ---
 
-<html lang="pt-BR" data-theme="margea-light">
+<html lang="en" data-theme="margea-light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />


### PR DESCRIPTION
## Problem

`SpaShell.astro` hardcodes `<html lang="pt-BR">` while the app is multi-locale (`en` / `es` / `pt` via i18next LanguageDetector). Screen readers and browser translation tools read the wrong language when the UI is English or Spanish.

## Change

- `src/i18n.ts`: after init and on `languageChanged`, set `document.documentElement.lang` to a BCP-47 base tag (`en` / `es` / `pt`). Guard when `document` is missing (SSR / non-browser).
- `src/layouts/SpaShell.astro`: static shell `lang` is now `en` to match `fallbackLng` instead of a fixed `pt-BR`.

No locale JSON files added or removed.

## Verify

- `prettier --check src/i18n.ts`
- `eslint src/i18n.ts`
- Pre-existing `tsc` errors elsewhere (missing Relay generated types) are unrelated; this change is limited to the two files above.