### PR TITLE
refactor: centralize PR filter sessionStorage key prefix

### DIFF
--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -18,7 +18,7 @@ import { PRGroupCard } from './PRGroupCard';
 import { PRGroupDetail } from './PRGroupDetail';
 import { reportError } from '../utils/errorReporting';
 import { PRGroup } from '../types';
-import { URL_SEARCH_PARAMS } from '../constants';
+import { FILTERS_STORAGE_KEY_PREFIX, URL_SEARCH_PARAMS } from '../constants';
 import { parseSortStrategy } from '../services/prSort';
 import { parseGroupingStrategy, parsePRState } from '../services/urlParams';
 import { PRListStats } from './PRListStats';
@@ -60,7 +60,7 @@ function PRListContent() {
     // Only restore on mount (when isRestored is false)
     if (isRestored) return;
 
-    const storageKey = `margea_filters_${location.pathname}`;
+    const storageKey = `${FILTERS_STORAGE_KEY_PREFIX}${location.pathname}`;
     const stored = sessionStorage.getItem(storageKey);
 
     if (stored) {
@@ -88,7 +88,7 @@ function PRListContent() {
   useEffect(() => {
     if (!isRestored) return;
 
-    const storageKey = `margea_filters_${location.pathname}`;
+    const storageKey = `${FILTERS_STORAGE_KEY_PREFIX}${location.pathname}`;
     sessionStorage.setItem(storageKey, searchParams.toString());
   }, [searchParams, location.pathname, isRestored]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,9 @@ export const MERGE_METHOD_ACTIONS = ['REBASE', 'SQUASH', 'MERGE'] as const;
 export const DEFAULT_MERGE_METHOD = MERGE_METHODS[0];
 export const MERGE_METHOD_STORAGE_KEY = 'margea_merge_method';
 
+/** sessionStorage key prefix for PR list filter persistence (pathname appended). */
+export const FILTERS_STORAGE_KEY_PREFIX = 'margea_filters_';
+
 export const THEME_LIGHT = 'margea-light';
 export const THEME_DARK = 'margea-dark';
 


### PR DESCRIPTION
## Summary
- Add `FILTERS_STORAGE_KEY_PREFIX` (`margea_filters_`) next to other storage key constants
- Use it for both sessionStorage read and write in `PRList`
- No behavior change; removes duplicated magic string

## Test plan
- [ ] Open a PR list route, set filters, reload — filters still restore from sessionStorage
- [ ] Navigate between pathnames — keys remain scoped per pathname
- [ ] Confirm sessionStorage keys still use prefix `margea_filters_`

Finding: filters-storage-prefix