### PR TITLE
fix(types): narrow Map.get in PRProvider.optimisticUpdate

### DIFF
--- a/src/context/PRProvider.tsx
+++ b/src/context/PRProvider.tsx
@@ -119,10 +119,10 @@ export function PRProvider({ children }: PRProviderProps) {
   const optimisticUpdate = useCallback(
     (prId: string, changes: Partial<PullRequest>) => {
       setPrMap((prev) => {
-        if (!prev.has(prId)) return prev;
-
         const next = new Map(prev);
-        const current = next.get(prId)!;
+        const current = next.get(prId);
+        if (current === undefined) return prev;
+
         next.set(prId, { ...current, ...changes });
 
         return next;


### PR DESCRIPTION
## Summary
- Rewrite `optimisticUpdate` to use `next.get(prId)` with an early return when `undefined`, instead of `Map.has` + non-null assertion.
- Behavior unchanged: missing keys still leave the previous map intact; present keys are still cloned and merged.

## Why
`Map.get` is typed as `T | undefined` even after `has`. The `!` hid a real narrow opportunity and matches other type-safety cleanups in the repo.

## Test plan
- [ ] Typecheck / CI green
- [ ] Optimistic bulk/update paths still update an existing PR in the map
- [ ] Calling optimisticUpdate with an unknown `prId` is a no-op