### PR TITLE
refactor: centralize theme localStorage key

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sun, Moon } from 'react-feather';
-import { THEMES, resolveTheme } from '../constants';
+import { THEMES, THEME_STORAGE_KEY, resolveTheme } from '../constants';
 
 type Theme = (typeof THEMES)[keyof typeof THEMES];
 
@@ -10,12 +10,15 @@ export function ThemeToggle() {
     const prefersDark = window.matchMedia(
       '(prefers-color-scheme: dark)',
     ).matches;
-    return resolveTheme(localStorage.getItem('theme'), prefersDark) as Theme;
+    return resolveTheme(
+      localStorage.getItem(THEME_STORAGE_KEY),
+      prefersDark,
+    ) as Theme;
   });
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
   const toggleTheme = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,9 @@ export const FILTERS_STORAGE_KEY_PREFIX = 'margea_filters_';
 export const THEME_LIGHT = 'margea-light';
 export const THEME_DARK = 'margea-dark';
 
+/** localStorage key for the selected theme (SpaShell inline script must match). */
+export const THEME_STORAGE_KEY = 'theme';
+
 export const THEMES = {
   LIGHT: THEME_LIGHT,
   DARK: THEME_DARK,

--- a/src/layouts/SpaShell.astro
+++ b/src/layouts/SpaShell.astro
@@ -15,6 +15,7 @@ import App from '../App';
     <title>Margea — GitHub PR Analyzer</title>
     <script>
       // Apply theme before paint to avoid flash; migrate legacy light/dark keys
+      // Must match THEME_STORAGE_KEY in src/constants.ts (inline script cannot import TS)
       const saved = localStorage.getItem('theme');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
       let theme = prefersDark ? 'margea-dark' : 'margea-light';


### PR DESCRIPTION
## Summary
- Add `THEME_STORAGE_KEY` (`'theme'`) next to other storage key constants
- Use it for both localStorage get and set in `ThemeToggle`
- Document the matching literal in `SpaShell` inline script (cannot import TS)
- No behavior change; storage key value remains `'theme'`

## Why
Theme used the magic string `'theme'` while `MERGE_METHOD_STORAGE_KEY`, `EFFECTIVE_MODE_STORAGE_KEY`, and `FILTERS_STORAGE_KEY_PREFIX` are centralized. Reduces typo risk and keeps storage keys discoverable in one place.

## Finding
**id:** theme-storage-key  
**taxonomy:** magic strings

## Test plan
- [ ] Toggle theme — preference still persists across reload
- [ ] Confirm localStorage key remains `theme`
- [ ] No FOUC: SpaShell pre-paint script still reads the same key