### PR TITLE
fix(prFilter): narrow filter fields without non-null assertions

### DIFF
--- a/src/services/prFilter.ts
+++ b/src/services/prFilter.ts
@@ -49,9 +49,7 @@ export function filterPullRequests(
   if (filters.owner) {
     const owner = filters.owner;
     filtered = filtered.filter((pr) =>
-      pr.repository.owner.login
-        .toLowerCase()
-        .includes(owner.toLowerCase()),
+      pr.repository.owner.login.toLowerCase().includes(owner.toLowerCase()),
     );
   }
 

--- a/src/services/prFilter.ts
+++ b/src/services/prFilter.ts
@@ -27,10 +27,11 @@ export function filterPullRequests(
   let filtered = [...prs];
 
   if (filters.repository) {
+    const repository = filters.repository;
     filtered = filtered.filter((pr) =>
       pr.repository.nameWithOwner
         .toLowerCase()
-        .includes(filters.repository!.toLowerCase()),
+        .includes(repository.toLowerCase()),
     );
   }
 
@@ -39,16 +40,18 @@ export function filterPullRequests(
   }
 
   if (filters.author) {
+    const author = filters.author;
     filtered = filtered.filter((pr) =>
-      pr.author?.login.toLowerCase().includes(filters.author!.toLowerCase()),
+      pr.author?.login.toLowerCase().includes(author.toLowerCase()),
     );
   }
 
   if (filters.owner) {
+    const owner = filters.owner;
     filtered = filtered.filter((pr) =>
       pr.repository.owner.login
         .toLowerCase()
-        .includes(filters.owner!.toLowerCase()),
+        .includes(owner.toLowerCase()),
     );
   }
 


### PR DESCRIPTION
## Problem
In `filterPullRequests`, after `if (filters.repository)` (and the same for `author` / `owner`), TypeScript still treats those optionals as possibly undefined inside the `.filter` callback, so the code used `filters.repository!` (and friends).

## Change
Capture each filter value in a local const right after the guard so the callback closes over a narrowed `string`. No behavior change.

## Verified
- `npx playwright test tests/pr-filter.spec.ts` — 7 passed