### PR TITLE
fix(types): drop Map.get non-null assertion in groupByHelper

### DIFF
--- a/src/services/prGrouping.ts
+++ b/src/services/prGrouping.ts
@@ -55,21 +55,22 @@ function groupByHelper(
   for (const pr of uniquePrs) {
     const { key, groupName } = keyExtractor(pr);
 
-    if (!groups.has(key)) {
+    let group = groups.get(key);
+    if (group === undefined) {
       const baseRef = normalizeBaseRef(pr.baseRefName);
       const labels = pr.labels?.nodes?.map((l) => l.name).sort() || [];
 
-      groups.set(key, {
+      group = {
         key,
         package: groupName,
         baseRef,
         labels,
         prs: [],
         count: 0,
-      });
+      };
+      groups.set(key, group);
     }
 
-    const group = groups.get(key)!;
     group.prs.push(pr);
     group.count++;
   }


### PR DESCRIPTION
## Summary
- Replace `groups.get(key)!` in `groupByHelper` with get-then-create, holding the local `PRGroup` reference from `Map.set`.
- Same type-safety family as #379 (`PRProvider` Map narrow); no behavior change.

## Finding
- **id:** prgrouping-map-narrow
- **taxonomy:** type safety

## Test plan
- [x] `npx playwright test tests/pr-grouping.spec.ts` (20 passed)
- [ ] CI green