### PR TITLE
fix(types): return Theme union from resolveTheme

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sun, Moon } from 'react-feather';
-import { THEMES, THEME_STORAGE_KEY, resolveTheme } from '../constants';
-
-type Theme = (typeof THEMES)[keyof typeof THEMES];
+import {
+  THEMES,
+  THEME_STORAGE_KEY,
+  resolveTheme,
+  type Theme,
+} from '../constants';
 
 export function ThemeToggle() {
   const [theme, setTheme] = useState<Theme>(() => {
     const prefersDark = window.matchMedia(
       '(prefers-color-scheme: dark)',
     ).matches;
-    return resolveTheme(
-      localStorage.getItem(THEME_STORAGE_KEY),
-      prefersDark,
-    ) as Theme;
+    return resolveTheme(localStorage.getItem(THEME_STORAGE_KEY), prefersDark);
   });
 
   useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,8 @@ export const THEMES = {
   DARK: THEME_DARK,
 } as const;
 
+export type Theme = (typeof THEMES)[keyof typeof THEMES];
+
 /** Client-side feature flag: effective access mode (clamped by token capability). */
 export const EFFECTIVE_MODE_STORAGE_KEY = 'margea_effective_mode';
 
@@ -81,7 +83,7 @@ export const EFFECTIVE_MODE_STORAGE_KEY = 'margea_effective_mode';
 export function resolveTheme(
   stored: string | null,
   prefersDark: boolean,
-): string {
+): Theme {
   if (stored === THEME_LIGHT || stored === THEME_DARK) return stored;
   if (stored === 'light') return THEME_LIGHT;
   if (stored === 'dark') return THEME_DARK;


### PR DESCRIPTION
## Summary
- Export `Theme` as `(typeof THEMES)[keyof typeof THEMES]` and type `resolveTheme` to return it instead of bare `string`.
- Drop the `as Theme` cast in `ThemeToggle` and import the shared type from constants.

Runtime behavior is unchanged; this is type-safety only after #381.

## Test plan
- [x] `npx playwright test tests/resolve-theme.spec.ts` (4 passed)
- [x] No new theme-related `tsc` errors

Finding: theme-cast-return-type