### PR TITLE
refactor: replace React.FC with plain function on CiStatusChart

### DIFF
--- a/src/components/CiStatusChart.tsx
+++ b/src/components/CiStatusChart.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface CiStatusChartProps {
   success: number;
   failure: number;
@@ -8,13 +6,13 @@ interface CiStatusChartProps {
   strokeWidth?: number;
 }
 
-export const CiStatusChart: React.FC<CiStatusChartProps> = ({
+export function CiStatusChart({
   success,
   failure,
   pending,
   size = 24,
   strokeWidth = 3,
-}) => {
+}: CiStatusChartProps) {
   const total = success + failure + pending;
   if (total === 0) {
     return null;
@@ -78,4 +76,4 @@ export const CiStatusChart: React.FC<CiStatusChartProps> = ({
       )}
     </svg>
   );
-};
+}


### PR DESCRIPTION
## Summary
- Convert `CiStatusChart` from `React.FC` to plain `export function` to match the rest of `src/components`.
- Remove unused `import React` (JSX transform does not need it).
- No visual or behavior change.

## Why
`React.FC` is unnecessary here (no children). It was the only `React.FC` usage under `src/`. Consistency + modern React typing.

Finding id: `cistatuschart-plain-fc`

## Test plan
- [ ] Typecheck / CI green
- [ ] CI status chart still renders on PR group cards and detail