### PR TITLE
test: extract shared makePR fixture for unit specs

### DIFF
--- a/tests/abort.spec.ts
+++ b/tests/abort.spec.ts
@@ -132,6 +132,8 @@ test.describe('abortableSleep', () => {
 
   test('resolves when signal is present but never aborted', async () => {
     const controller = new AbortController();
-    await expect(abortableSleep(40, controller.signal)).resolves.toBeUndefined();
+    await expect(
+      abortableSleep(40, controller.signal),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tests/adaptive-scope-fetcher.spec.ts
+++ b/tests/adaptive-scope-fetcher.spec.ts
@@ -7,36 +7,9 @@ import {
 } from '../src/services/AdaptiveScopeFetcher';
 import type { PullRequest } from '../src/types';
 import { createAbortError, isAbortError } from '../src/utils/abort';
+import { makePR } from './utils/makePR';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-function makePR(id: string, createdAt: string): PullRequest {
-  return {
-    id,
-    number: Number(id.replace(/\D/g, '') || 1),
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt,
-    updatedAt: createdAt,
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `branch-${id}`,
-    author: null,
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-  };
-}
 
 function page(prs: PullRequest[], issueCount = prs.length): PageResult {
   return { prs, issueCount, hasNextPage: false, endCursor: null };
@@ -65,7 +38,7 @@ test.describe('createScopeStream', () => {
       queries.push(query);
       signals.push(signal);
       call += 1;
-      return page([makePR(`pr-${call}`, '2026-01-07T12:00:00Z')]);
+      return page([makePR(`pr-${call}`, { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
     };
 
     const end = new Date('2026-01-08T00:00:00Z');
@@ -132,7 +105,7 @@ test.describe('createScopeStream', () => {
 
   test('abort while idle completes the generator on next pull', async () => {
     const fetchPage: PageFetcher = async () =>
-      page([makePR('pr-1', '2026-01-07T12:00:00Z')]);
+      page([makePR('pr-1', { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
 
     const end = new Date('2026-01-08T00:00:00Z');
     const start = new Date('2026-01-07T00:00:00Z');
@@ -155,7 +128,7 @@ test.describe('createScopeStream', () => {
     let calls = 0;
     const fetchPage: PageFetcher = async () => {
       calls += 1;
-      return page([makePR(`pr-${calls}`, '2026-01-07T12:00:00Z')]);
+      return page([makePR(`pr-${calls}`, { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
     };
 
     const end = new Date('2026-01-08T00:00:00Z');
@@ -184,7 +157,7 @@ test.describe('createScopeStream', () => {
       if (query.includes('2026-01-01..2026-01-31')) {
         return page([], 1001);
       }
-      return page([makePR(`pr-${queries.length}`, '2026-01-15T00:00:00Z')]);
+      return page([makePR(`pr-${queries.length}`, { createdAt: '2026-01-15T00:00:00Z', updatedAt: '2026-01-15T00:00:00Z' })]);
     };
 
     const end = new Date('2026-01-31T00:00:00Z');
@@ -209,14 +182,14 @@ test.describe('createScopeStream', () => {
     const fetchPage: PageFetcher = async (_query, cursor) => {
       if (!cursor) {
         return {
-          prs: [makePR('p1', '2026-01-07T12:00:00Z')],
+          prs: [makePR('p1', { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })],
           issueCount: 2,
           hasNextPage: true,
           endCursor: 'cursor-1',
         };
       }
       return {
-        prs: [makePR('p2', '2026-01-07T11:00:00Z')],
+        prs: [makePR('p2', { createdAt: '2026-01-07T11:00:00Z', updatedAt: '2026-01-07T11:00:00Z' })],
         issueCount: 2,
         hasNextPage: false,
         endCursor: null,

--- a/tests/adaptive-scope-fetcher.spec.ts
+++ b/tests/adaptive-scope-fetcher.spec.ts
@@ -38,7 +38,12 @@ test.describe('createScopeStream', () => {
       queries.push(query);
       signals.push(signal);
       call += 1;
-      return page([makePR(`pr-${call}`, { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
+      return page([
+        makePR(`pr-${call}`, {
+          createdAt: '2026-01-07T12:00:00Z',
+          updatedAt: '2026-01-07T12:00:00Z',
+        }),
+      ]);
     };
 
     const end = new Date('2026-01-08T00:00:00Z');
@@ -105,7 +110,12 @@ test.describe('createScopeStream', () => {
 
   test('abort while idle completes the generator on next pull', async () => {
     const fetchPage: PageFetcher = async () =>
-      page([makePR('pr-1', { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
+      page([
+        makePR('pr-1', {
+          createdAt: '2026-01-07T12:00:00Z',
+          updatedAt: '2026-01-07T12:00:00Z',
+        }),
+      ]);
 
     const end = new Date('2026-01-08T00:00:00Z');
     const start = new Date('2026-01-07T00:00:00Z');
@@ -128,7 +138,12 @@ test.describe('createScopeStream', () => {
     let calls = 0;
     const fetchPage: PageFetcher = async () => {
       calls += 1;
-      return page([makePR(`pr-${calls}`, { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })]);
+      return page([
+        makePR(`pr-${calls}`, {
+          createdAt: '2026-01-07T12:00:00Z',
+          updatedAt: '2026-01-07T12:00:00Z',
+        }),
+      ]);
     };
 
     const end = new Date('2026-01-08T00:00:00Z');
@@ -157,7 +172,12 @@ test.describe('createScopeStream', () => {
       if (query.includes('2026-01-01..2026-01-31')) {
         return page([], 1001);
       }
-      return page([makePR(`pr-${queries.length}`, { createdAt: '2026-01-15T00:00:00Z', updatedAt: '2026-01-15T00:00:00Z' })]);
+      return page([
+        makePR(`pr-${queries.length}`, {
+          createdAt: '2026-01-15T00:00:00Z',
+          updatedAt: '2026-01-15T00:00:00Z',
+        }),
+      ]);
     };
 
     const end = new Date('2026-01-31T00:00:00Z');
@@ -182,14 +202,24 @@ test.describe('createScopeStream', () => {
     const fetchPage: PageFetcher = async (_query, cursor) => {
       if (!cursor) {
         return {
-          prs: [makePR('p1', { createdAt: '2026-01-07T12:00:00Z', updatedAt: '2026-01-07T12:00:00Z' })],
+          prs: [
+            makePR('p1', {
+              createdAt: '2026-01-07T12:00:00Z',
+              updatedAt: '2026-01-07T12:00:00Z',
+            }),
+          ],
           issueCount: 2,
           hasNextPage: true,
           endCursor: 'cursor-1',
         };
       }
       return {
-        prs: [makePR('p2', { createdAt: '2026-01-07T11:00:00Z', updatedAt: '2026-01-07T11:00:00Z' })],
+        prs: [
+          makePR('p2', {
+            createdAt: '2026-01-07T11:00:00Z',
+            updatedAt: '2026-01-07T11:00:00Z',
+          }),
+        ],
         issueCount: 2,
         hasNextPage: false,
         endCursor: null,

--- a/tests/bulk-action-confirm.spec.ts
+++ b/tests/bulk-action-confirm.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/services/mergeMethod';
 import { MERGE_METHOD_STORAGE_KEY } from '../src/constants';
 import type { PullRequest } from '../src/types';
+import { makePR } from './utils/makePR';
 
 /** Minimal sessionStorage for unit-testing merge method helpers outside the browser. */
 function installMemorySessionStorage(): () => void {
@@ -44,34 +45,6 @@ function installMemorySessionStorage(): () => void {
       configurable: true,
       value: previous,
     });
-  };
-}
-
-function makePR(id: string): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
   };
 }
 

--- a/tests/ci-status.spec.ts
+++ b/tests/ci-status.spec.ts
@@ -1,44 +1,10 @@
 import { test, expect } from '@playwright/test';
-import type { PullRequest } from '../src/types';
 import {
   countCiStatuses,
   formatCiStatusTooltip,
   type CiStatusCounts,
 } from '../src/services/ciStatus';
-
-/**
- * Minimal fixture: countCiStatuses only reads ciStatus.
- */
-function makePR(
-  id: string,
-  ciStatus: PullRequest['ciStatus'] = null,
-): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-  };
-}
+import { makePR } from './utils/makePR';
 
 const labels = {
   status: 'CI',
@@ -59,12 +25,12 @@ test.describe('countCiStatuses', () => {
 
   test('counts mixed SUCCESS, FAILURE, and PENDING', () => {
     const prs = [
-      makePR('s1', 'SUCCESS'),
-      makePR('s2', 'SUCCESS'),
-      makePR('f1', 'FAILURE'),
-      makePR('p1', 'PENDING'),
-      makePR('p2', 'PENDING'),
-      makePR('p3', 'PENDING'),
+      makePR('s1', { ciStatus: 'SUCCESS' }),
+      makePR('s2', { ciStatus: 'SUCCESS' }),
+      makePR('f1', { ciStatus: 'FAILURE' }),
+      makePR('p1', { ciStatus: 'PENDING' }),
+      makePR('p2', { ciStatus: 'PENDING' }),
+      makePR('p3', { ciStatus: 'PENDING' }),
     ];
 
     expect(countCiStatuses(prs)).toEqual({
@@ -77,11 +43,11 @@ test.describe('countCiStatuses', () => {
 
   test('null ciStatus is ignored (not counted in total)', () => {
     const prs = [
-      makePR('s1', 'SUCCESS'),
-      makePR('n1', null),
-      makePR('f1', 'FAILURE'),
-      makePR('n2', null),
-      makePR('p1', 'PENDING'),
+      makePR('s1', { ciStatus: 'SUCCESS' }),
+      makePR('n1'),
+      makePR('f1', { ciStatus: 'FAILURE' }),
+      makePR('n2'),
+      makePR('p1', { ciStatus: 'PENDING' }),
     ];
 
     expect(countCiStatuses(prs)).toEqual({
@@ -93,7 +59,7 @@ test.describe('countCiStatuses', () => {
   });
 
   test('all null yields zeros', () => {
-    expect(countCiStatuses([makePR('a', null), makePR('b', null)])).toEqual({
+    expect(countCiStatuses([makePR('a'), makePR('b')])).toEqual({
       success: 0,
       failure: 0,
       pending: 0,
@@ -102,19 +68,19 @@ test.describe('countCiStatuses', () => {
   });
 
   test('single status buckets', () => {
-    expect(countCiStatuses([makePR('s', 'SUCCESS')])).toEqual({
+    expect(countCiStatuses([makePR('s', { ciStatus: 'SUCCESS' })])).toEqual({
       success: 1,
       failure: 0,
       pending: 0,
       total: 1,
     });
-    expect(countCiStatuses([makePR('f', 'FAILURE')])).toEqual({
+    expect(countCiStatuses([makePR('f', { ciStatus: 'FAILURE' })])).toEqual({
       success: 0,
       failure: 1,
       pending: 0,
       total: 1,
     });
-    expect(countCiStatuses([makePR('p', 'PENDING')])).toEqual({
+    expect(countCiStatuses([makePR('p', { ciStatus: 'PENDING' })])).toEqual({
       success: 0,
       failure: 0,
       pending: 1,

--- a/tests/pr-fetch-session.spec.ts
+++ b/tests/pr-fetch-session.spec.ts
@@ -13,36 +13,9 @@ import {
   type StreamFactory,
 } from '../src/services/prFetchSession';
 import type { PullRequest } from '../src/types';
+import { makePR } from './utils/makePR';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-function makePR(id: string): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-07T12:00:00Z',
-    updatedAt: '2026-01-07T12:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: null,
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-  };
-}
 
 function page(prs: PullRequest[], issueCount = prs.length): PageResult {
   return { prs, issueCount, hasNextPage: false, endCursor: null };

--- a/tests/pr-filter.spec.ts
+++ b/tests/pr-filter.spec.ts
@@ -1,56 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { PullRequest } from '../src/types';
 import { filterPullRequests } from '../src/services/prFilter';
-
-/**
- * Minimal fixture: only fields filterPullRequests reads
- * (repository.nameWithOwner, repository.owner.login, author?.login, state).
- */
-function makePR(
-  id: string,
-  overrides: {
-    state?: PullRequest['state'];
-    author?: PullRequest['author'];
-    repository?: Partial<PullRequest['repository']> & {
-      nameWithOwner?: string;
-      owner?: { login: string };
-    };
-  } = {},
-): PullRequest {
-  const nameWithOwner = overrides.repository?.nameWithOwner ?? 'acme/app';
-  const [defaultOwner, defaultName] = nameWithOwner.includes('/')
-    ? nameWithOwner.split('/')
-    : ['acme', nameWithOwner];
-
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: overrides.state ?? 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author:
-      overrides.author === undefined
-        ? { login: 'bot', avatarUrl: '' }
-        : overrides.author,
-    labels: null,
-    repository: {
-      id: overrides.repository?.id ?? 'repo',
-      name: overrides.repository?.name ?? defaultName,
-      nameWithOwner,
-      owner: overrides.repository?.owner ?? { login: defaultOwner },
-    },
-  };
-}
+import { makePR } from './utils/makePR';
 
 const fixturePRs: PullRequest[] = [
   makePR('open-acme-bot', {

--- a/tests/pr-grouping.spec.ts
+++ b/tests/pr-grouping.spec.ts
@@ -1,35 +1,6 @@
 import { test, expect } from '@playwright/test';
-import type { PullRequest } from '../src/types';
 import { groupPullRequests } from '../src/services/prGrouping';
-
-function makePR(id: string, overrides: Partial<PullRequest> = {}): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-    ...overrides,
-  };
-}
+import { makePR } from './utils/makePR';
 
 test.describe('groupPullRequests — renovate (default)', () => {
   test('groups by normalized title + author', () => {

--- a/tests/pr-sort.spec.ts
+++ b/tests/pr-sort.spec.ts
@@ -2,35 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { PRGroup, PullRequest } from '../src/types';
 import { parseSortStrategy, sortGroups } from '../src/services/prSort';
 import { DEFAULT_SORT_STRATEGY } from '../src/constants';
-
-function makePR(id: string, overrides: Partial<PullRequest> = {}): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-    ...overrides,
-  };
-}
+import { makePR } from './utils/makePR';
 
 function makeGroup(
   key: string,

--- a/tests/pr-stats.spec.ts
+++ b/tests/pr-stats.spec.ts
@@ -15,10 +15,22 @@ test.describe('calculateStats', () => {
 
   test('counts by state and unique repositories', () => {
     const prs = [
-      makePR('o1', { state: 'OPEN', repository: { nameWithOwner: 'acme/one' } }),
-      makePR('o2', { state: 'OPEN', repository: { nameWithOwner: 'acme/one' } }),
-      makePR('m1', { state: 'MERGED', repository: { nameWithOwner: 'acme/two' } }),
-      makePR('c1', { state: 'CLOSED', repository: { nameWithOwner: 'other/lib' } }),
+      makePR('o1', {
+        state: 'OPEN',
+        repository: { nameWithOwner: 'acme/one' },
+      }),
+      makePR('o2', {
+        state: 'OPEN',
+        repository: { nameWithOwner: 'acme/one' },
+      }),
+      makePR('m1', {
+        state: 'MERGED',
+        repository: { nameWithOwner: 'acme/two' },
+      }),
+      makePR('c1', {
+        state: 'CLOSED',
+        repository: { nameWithOwner: 'other/lib' },
+      }),
     ];
 
     expect(calculateStats(prs)).toEqual({
@@ -33,7 +45,10 @@ test.describe('calculateStats', () => {
   test('single open PR counts total, open, and one repository', () => {
     expect(
       calculateStats([
-        makePR('only', { state: 'OPEN', repository: { nameWithOwner: 'acme/app' } }),
+        makePR('only', {
+          state: 'OPEN',
+          repository: { nameWithOwner: 'acme/app' },
+        }),
       ]),
     ).toEqual({
       total: 1,
@@ -47,8 +62,14 @@ test.describe('calculateStats', () => {
   test('all same repository still reports repositories: 1', () => {
     const prs = [
       makePR('a', { state: 'OPEN', repository: { nameWithOwner: 'acme/app' } }),
-      makePR('b', { state: 'MERGED', repository: { nameWithOwner: 'acme/app' } }),
-      makePR('c', { state: 'CLOSED', repository: { nameWithOwner: 'acme/app' } }),
+      makePR('b', {
+        state: 'MERGED',
+        repository: { nameWithOwner: 'acme/app' },
+      }),
+      makePR('c', {
+        state: 'CLOSED',
+        repository: { nameWithOwner: 'acme/app' },
+      }),
     ];
 
     expect(calculateStats(prs)).toEqual({
@@ -75,7 +96,9 @@ test.describe('calculateStats', () => {
     });
 
     expect(
-      calculateStats([makePR('c1', { state: 'CLOSED', repository: { nameWithOwner: 'x/y' } })]),
+      calculateStats([
+        makePR('c1', { state: 'CLOSED', repository: { nameWithOwner: 'x/y' } }),
+      ]),
     ).toEqual({
       total: 1,
       open: 0,

--- a/tests/pr-stats.spec.ts
+++ b/tests/pr-stats.spec.ts
@@ -1,48 +1,6 @@
 import { test, expect } from '@playwright/test';
-import type { PullRequest } from '../src/types';
 import { calculateStats } from '../src/services/prStats';
-
-/**
- * Minimal fixture: calculateStats only reads state and repository.nameWithOwner.
- */
-function makePR(
-  id: string,
-  overrides: {
-    state?: PullRequest['state'];
-    nameWithOwner?: string;
-  } = {},
-): PullRequest {
-  const nameWithOwner = overrides.nameWithOwner ?? 'acme/app';
-  const [owner, name] = nameWithOwner.includes('/')
-    ? nameWithOwner.split('/')
-    : ['acme', nameWithOwner];
-
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: overrides.state ?? 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: nameWithOwner,
-      name,
-      nameWithOwner,
-      owner: { login: owner },
-    },
-  };
-}
+import { makePR } from './utils/makePR';
 
 test.describe('calculateStats', () => {
   test('empty list returns zero counts', () => {
@@ -57,10 +15,10 @@ test.describe('calculateStats', () => {
 
   test('counts by state and unique repositories', () => {
     const prs = [
-      makePR('o1', { state: 'OPEN', nameWithOwner: 'acme/one' }),
-      makePR('o2', { state: 'OPEN', nameWithOwner: 'acme/one' }),
-      makePR('m1', { state: 'MERGED', nameWithOwner: 'acme/two' }),
-      makePR('c1', { state: 'CLOSED', nameWithOwner: 'other/lib' }),
+      makePR('o1', { state: 'OPEN', repository: { nameWithOwner: 'acme/one' } }),
+      makePR('o2', { state: 'OPEN', repository: { nameWithOwner: 'acme/one' } }),
+      makePR('m1', { state: 'MERGED', repository: { nameWithOwner: 'acme/two' } }),
+      makePR('c1', { state: 'CLOSED', repository: { nameWithOwner: 'other/lib' } }),
     ];
 
     expect(calculateStats(prs)).toEqual({
@@ -75,7 +33,7 @@ test.describe('calculateStats', () => {
   test('single open PR counts total, open, and one repository', () => {
     expect(
       calculateStats([
-        makePR('only', { state: 'OPEN', nameWithOwner: 'acme/app' }),
+        makePR('only', { state: 'OPEN', repository: { nameWithOwner: 'acme/app' } }),
       ]),
     ).toEqual({
       total: 1,
@@ -88,9 +46,9 @@ test.describe('calculateStats', () => {
 
   test('all same repository still reports repositories: 1', () => {
     const prs = [
-      makePR('a', { state: 'OPEN', nameWithOwner: 'acme/app' }),
-      makePR('b', { state: 'MERGED', nameWithOwner: 'acme/app' }),
-      makePR('c', { state: 'CLOSED', nameWithOwner: 'acme/app' }),
+      makePR('a', { state: 'OPEN', repository: { nameWithOwner: 'acme/app' } }),
+      makePR('b', { state: 'MERGED', repository: { nameWithOwner: 'acme/app' } }),
+      makePR('c', { state: 'CLOSED', repository: { nameWithOwner: 'acme/app' } }),
     ];
 
     expect(calculateStats(prs)).toEqual({
@@ -105,8 +63,8 @@ test.describe('calculateStats', () => {
   test('only merged and only closed', () => {
     expect(
       calculateStats([
-        makePR('m1', { state: 'MERGED', nameWithOwner: 'a/r' }),
-        makePR('m2', { state: 'MERGED', nameWithOwner: 'b/r' }),
+        makePR('m1', { state: 'MERGED', repository: { nameWithOwner: 'a/r' } }),
+        makePR('m2', { state: 'MERGED', repository: { nameWithOwner: 'b/r' } }),
       ]),
     ).toEqual({
       total: 2,
@@ -117,7 +75,7 @@ test.describe('calculateStats', () => {
     });
 
     expect(
-      calculateStats([makePR('c1', { state: 'CLOSED', nameWithOwner: 'x/y' })]),
+      calculateStats([makePR('c1', { state: 'CLOSED', repository: { nameWithOwner: 'x/y' } })]),
     ).toEqual({
       total: 1,
       open: 0,

--- a/tests/pr-store-pull.spec.ts
+++ b/tests/pr-store-pull.spec.ts
@@ -8,36 +8,9 @@ import {
 import { createSerialQueue } from '../src/services/serialQueue';
 import { pullStreamsUntilIdle } from '../src/services/prStorePull';
 import type { PullRequest } from '../src/types';
+import { makePR } from './utils/makePR';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-function makePR(id: string): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-07T12:00:00Z',
-    updatedAt: '2026-01-07T12:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: null,
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-  };
-}
 
 function page(prs: PullRequest[], issueCount = prs.length): PageResult {
   return { prs, issueCount, hasNextPage: false, endCursor: null };

--- a/tests/resolve-theme.spec.ts
+++ b/tests/resolve-theme.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '@playwright/test';
-import {
-  resolveTheme,
-  THEME_LIGHT,
-  THEME_DARK,
-} from '../src/constants';
+import { resolveTheme, THEME_LIGHT, THEME_DARK } from '../src/constants';
 
 test.describe('resolveTheme', () => {
   test('null stored value falls back to prefersDark', () => {

--- a/tests/utils/makePR.ts
+++ b/tests/utils/makePR.ts
@@ -1,0 +1,56 @@
+import type { PullRequest } from '../../src/types';
+
+/** Overrides for makePR; repository is shallow-merged (owner nested). */
+export type MakePROverrides = Partial<
+  Omit<PullRequest, 'repository' | 'author'>
+> & {
+  author?: PullRequest['author'];
+  repository?: Partial<Omit<PullRequest['repository'], 'owner'>> & {
+    owner?: Partial<PullRequest['repository']['owner']>;
+  };
+};
+
+/**
+ * Shared PullRequest fixture for unit specs.
+ * Covers the common fields; pass overrides for fields under test.
+ */
+export function makePR(
+  id: string,
+  overrides: MakePROverrides = {},
+): PullRequest {
+  const { repository: repoOverrides, author, ...rest } = overrides;
+
+  const nameWithOwner = repoOverrides?.nameWithOwner ?? 'acme/app';
+  const [derivedOwner, derivedName] = nameWithOwner.includes('/')
+    ? nameWithOwner.split('/')
+    : ['acme', nameWithOwner];
+
+  return {
+    id,
+    number: 1,
+    title: id,
+    body: null,
+    state: 'OPEN',
+    additions: 0,
+    deletions: 0,
+    ciStatus: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    mergedAt: null,
+    closedAt: null,
+    url: `https://example.com/${id}`,
+    baseRefName: 'main',
+    headRefName: `b-${id}`,
+    author: author === undefined ? { login: 'bot', avatarUrl: '' } : author,
+    labels: null,
+    repository: {
+      id: repoOverrides?.id ?? 'repo',
+      name: repoOverrides?.name ?? derivedName,
+      nameWithOwner,
+      owner: {
+        login: repoOverrides?.owner?.login ?? derivedOwner,
+      },
+    },
+    ...rest,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `tests/utils/makePR.ts` as a single shared `makePR(id, overrides?)` PullRequest fixture.
- Migrate pure unit specs that each redefined a local `makePR` (pr-stats, pr-sort, pr-grouping, pr-filter, ci-status, bulk-action-confirm, adaptive-scope-fetcher, pr-store-pull, pr-fetch-session).
- Removes ~9 near-copies so `PullRequest` field changes only need one update.

## Finding
- **id:** shared-makepr-fixture
- **taxonomy:** reimplementations / DRY

## Test plan
- [x] `npx playwright test` on the 9 migrated unit specs (76 tests passed)
- [ ] CI green on this PR