### PR TITLE
style(tests): prettier-format abort and resolve-theme unit specs

### DIFF
--- a/tests/abort.spec.ts
+++ b/tests/abort.spec.ts
@@ -132,6 +132,8 @@ test.describe('abortableSleep', () => {
 
   test('resolves when signal is present but never aborted', async () => {
     const controller = new AbortController();
-    await expect(abortableSleep(40, controller.signal)).resolves.toBeUndefined();
+    await expect(
+      abortableSleep(40, controller.signal),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tests/resolve-theme.spec.ts
+++ b/tests/resolve-theme.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '@playwright/test';
-import {
-  resolveTheme,
-  THEME_LIGHT,
-  THEME_DARK,
-} from '../src/constants';
+import { resolveTheme, THEME_LIGHT, THEME_DARK } from '../src/constants';
 
 test.describe('resolveTheme', () => {
   test('null stored value falls back to prefersDark', () => {


### PR DESCRIPTION
## Summary
- Run Prettier on `tests/abort.spec.ts` and `tests/resolve-theme.spec.ts` so `prettier --check` passes in CI/Autorelease.
- Formatting only (line wrapping / import collapse); no logic changes.

## Why
These unit test files landed without Prettier formatting and currently fail `prettier --check` on main (seen in PR #387 Autorelease logs), blocking green CI for unrelated PRs.

## Finding
- id: `prettier-orphan-tests`
- taxonomy: statically caught issues

## Test plan
- [x] `npx -y prettier --check tests/abort.spec.ts tests/resolve-theme.spec.ts` passes
- [ ] CI prettier job green on this PR