### PR TITLE
test: use shared makePR fixture in use-stable-pr-groups

### DIFF
--- a/tests/use-stable-pr-groups.spec.ts
+++ b/tests/use-stable-pr-groups.spec.ts
@@ -335,6 +335,8 @@ function createHarness(initial: HarnessOptions) {
       groupingStrategy,
       sortStrategy,
     );
+    // Test harness: intentionally capture latest hook output for assertions.
+    // eslint-disable-next-line react-hooks/globals -- harness bridge, not app code
     api = {
       keys: groups.map((g) => g.key),
       counts: groups.map((g) => g.count),

--- a/tests/use-stable-pr-groups.spec.ts
+++ b/tests/use-stable-pr-groups.spec.ts
@@ -10,6 +10,7 @@ import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 import type { GroupingStrategy, PullRequest, SortStrategy } from '../src/types';
 import { useStablePRGroups } from '../src/hooks/useStablePRGroups';
+import { makePR } from './utils/makePR';
 
 /** React act() needs this flag outside Jest/RTL. */
 function enableReactActEnvironment() {
@@ -286,35 +287,6 @@ function installMinimalDom() {
   define('requestAnimationFrame', windowObj.requestAnimationFrame);
   define('cancelAnimationFrame', windowObj.cancelAnimationFrame);
   define('getComputedStyle', windowObj.getComputedStyle);
-}
-
-function makePR(id: string, overrides: Partial<PullRequest> = {}): PullRequest {
-  return {
-    id,
-    number: 1,
-    title: id,
-    body: null,
-    state: 'OPEN',
-    additions: 0,
-    deletions: 0,
-    ciStatus: null,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    mergedAt: null,
-    closedAt: null,
-    url: `https://example.com/${id}`,
-    baseRefName: 'main',
-    headRefName: `b-${id}`,
-    author: { login: 'bot', avatarUrl: '' },
-    labels: null,
-    repository: {
-      id: 'repo',
-      name: 'app',
-      nameWithOwner: 'acme/app',
-      owner: { login: 'acme' },
-    },
-    ...overrides,
-  };
 }
 
 /** Renovate grouping key = normalizedTitle|author */


### PR DESCRIPTION
## Summary
- Replace the leftover local `makePR` in `tests/use-stable-pr-groups.spec.ts` with the shared fixture from `tests/utils/makePR.ts` (extracted in #388).
- Call sites already match the shared signature (`id` + optional overrides); no behavior change.

## Context
#388 migrated 9 unit specs onto `tests/utils/makePR.ts`. `use-stable-pr-groups.spec.ts` landed in parallel as #389 still defining its own copy — one leftover reimplementation.

## Test plan
- [x] `npx playwright test tests/use-stable-pr-groups.spec.ts` — 6 passed